### PR TITLE
Consolidate troubleshooting tools into one

### DIFF
--- a/src/ecs-mcp-server/awslabs/ecs_mcp_server/api/__init__.py
+++ b/src/ecs-mcp-server/awslabs/ecs_mcp_server/api/__init__.py
@@ -1,0 +1,12 @@
+"""
+MCP server API for ECS tools.
+
+This module provides API endpoints for the MCP server.
+"""
+
+from .ecs_troubleshooting import ecs_troubleshooting_tool
+
+# Export the functions that will be available to the MCP server
+__all__ = [
+    'ecs_troubleshooting_tool',
+]

--- a/src/ecs-mcp-server/awslabs/ecs_mcp_server/api/ecs_troubleshooting.py
+++ b/src/ecs-mcp-server/awslabs/ecs_mcp_server/api/ecs_troubleshooting.py
@@ -1,5 +1,5 @@
 """
-Consolidated ECS troubleshooting tool that aggregates all troubleshooting functionality.
+ECS troubleshooting tool that aggregates all troubleshooting functionality.
 
 This module provides a single entry point for all ECS troubleshooting operations
 that were previously available as separate tools.
@@ -200,7 +200,7 @@ def generate_troubleshooting_docs():
     
     # Combine all documentation sections
     doc_header = """
-Consolidated ECS troubleshooting tool with multiple diagnostic actions.
+ECS troubleshooting tool with multiple diagnostic actions.
 
 This tool provides access to all ECS troubleshooting operations through a single
 interface. Use the 'action' parameter to specify which troubleshooting operation
@@ -269,7 +269,7 @@ def ecs_troubleshooting_tool(
     parameters: Optional[Dict[str, Any]] = None
 ) -> Dict[str, Any]:
     """
-    Consolidated ECS troubleshooting tool.
+    ECS troubleshooting tool.
     
     This tool provides access to all ECS troubleshooting operations through a single
     interface. Use the 'action' parameter to specify which troubleshooting operation

--- a/src/ecs-mcp-server/awslabs/ecs_mcp_server/api/ecs_troubleshooting.py
+++ b/src/ecs-mcp-server/awslabs/ecs_mcp_server/api/ecs_troubleshooting.py
@@ -1,0 +1,322 @@
+"""
+Consolidated ECS troubleshooting tool that aggregates all troubleshooting functionality.
+
+This module provides a single entry point for all ECS troubleshooting operations
+that were previously available as separate tools.
+"""
+
+import logging
+from typing import Dict, Any, Optional, Literal
+
+from awslabs.ecs_mcp_server.api.troubleshooting_tools.get_ecs_troubleshooting_guidance import (
+    get_ecs_troubleshooting_guidance,
+)
+from awslabs.ecs_mcp_server.api.troubleshooting_tools.fetch_cloudformation_status import (
+    fetch_cloudformation_status,
+)
+from awslabs.ecs_mcp_server.api.troubleshooting_tools.fetch_service_events import (
+    fetch_service_events,
+)
+from awslabs.ecs_mcp_server.api.troubleshooting_tools.fetch_task_failures import (
+    fetch_task_failures,
+)
+from awslabs.ecs_mcp_server.api.troubleshooting_tools.fetch_task_logs import (
+    fetch_task_logs,
+)
+from awslabs.ecs_mcp_server.api.troubleshooting_tools.detect_image_pull_failures import (
+    detect_image_pull_failures,
+)
+
+logger = logging.getLogger(__name__)
+
+# Type definitions
+TroubleshootingAction = Literal[
+    "get_ecs_troubleshooting_guidance",
+    "fetch_cloudformation_status", 
+    "fetch_service_events",
+    "fetch_task_failures",
+    "fetch_task_logs",
+    "detect_image_pull_failures"
+]
+
+# Combined actions configuration with inline parameter transformers and documentation
+ACTIONS = {
+    "get_ecs_troubleshooting_guidance": {
+        "func": get_ecs_troubleshooting_guidance,
+        "required_params": ["app_name"],
+        "optional_params": ["symptoms_description"],
+        "transformer": lambda app_name, params: {
+            "app_name": app_name,
+            "symptoms_description": params.get("symptoms_description")
+        },
+        "description": "Initial assessment and data collection",
+        "param_descriptions": {
+            "app_name": "The name of the application/stack to troubleshoot",
+            "symptoms_description": "Description of symptoms experienced by the user"
+        },
+        "example": 'action="get_ecs_troubleshooting_guidance", parameters={"symptoms_description": "ALB returning 503 errors"}'
+    },
+    "fetch_cloudformation_status": {
+        "func": fetch_cloudformation_status,
+        "required_params": ["stack_id"],
+        "optional_params": [],
+        "transformer": lambda app_name, params: {
+            "stack_id": params.get("stack_id", app_name)
+        },
+        "description": "Infrastructure-level diagnostics for CloudFormation stacks",
+        "param_descriptions": {
+            "stack_id": "The CloudFormation stack identifier to analyze"
+        },
+        "example": 'action="fetch_cloudformation_status", parameters={"stack_id": "my-app-stack"}'
+    },
+    "fetch_service_events": {
+        "func": fetch_service_events,
+        "required_params": ["app_name", "cluster_name", "service_name"],
+        "optional_params": ["time_window", "start_time", "end_time"],
+        "transformer": lambda app_name, params: {
+            "app_name": app_name,
+            "cluster_name": params["cluster_name"],
+            "service_name": params["service_name"],
+            "time_window": params.get("time_window", 3600),
+            "start_time": params.get("start_time"),
+            "end_time": params.get("end_time")
+        },
+        "description": "Service-level diagnostics for ECS services",
+        "param_descriptions": {
+            "app_name": "The name of the application to analyze",
+            "cluster_name": "The name of the ECS cluster",
+            "service_name": "The name of the ECS service to analyze",
+            "time_window": "Time window in seconds to look back for events (default: 3600)",
+            "start_time": "Explicit start time for the analysis window (UTC, takes precedence over time_window if provided)",
+            "end_time": "Explicit end time for the analysis window (UTC, defaults to current time if not provided)"
+        },
+        "example": 'action="fetch_service_events", parameters={"cluster_name": "my-cluster", "service_name": "my-service", "time_window": 7200}'
+    },
+    "fetch_task_failures": {
+        "func": fetch_task_failures,
+        "required_params": ["app_name", "cluster_name"],
+        "optional_params": ["time_window", "start_time", "end_time"],
+        "transformer": lambda app_name, params: {
+            "app_name": app_name,
+            "cluster_name": params["cluster_name"],
+            "time_window": params.get("time_window", 3600),
+            "start_time": params.get("start_time"),
+            "end_time": params.get("end_time")
+        },
+        "description": "Task-level diagnostics for ECS task failures",
+        "param_descriptions": {
+            "app_name": "The name of the application to analyze",
+            "cluster_name": "The name of the ECS cluster",
+            "time_window": "Time window in seconds to look back for failures (default: 3600)",
+            "start_time": "Explicit start time for the analysis window (UTC, takes precedence over time_window if provided)",
+            "end_time": "Explicit end time for the analysis window (UTC, defaults to current time if not provided)"
+        },
+        "example": 'action="fetch_task_failures", parameters={"cluster_name": "my-cluster", "time_window": 3600}'
+    },
+    "fetch_task_logs": {
+        "func": fetch_task_logs,
+        "required_params": ["app_name", "cluster_name"],
+        "optional_params": ["task_id", "time_window", "filter_pattern", "start_time", "end_time"],
+        "transformer": lambda app_name, params: {
+            "app_name": app_name,
+            "cluster_name": params["cluster_name"],
+            "task_id": params.get("task_id"),
+            "time_window": params.get("time_window", 3600),
+            "filter_pattern": params.get("filter_pattern"),
+            "start_time": params.get("start_time"),
+            "end_time": params.get("end_time")
+        },
+        "description": "Application-level diagnostics through CloudWatch logs",
+        "param_descriptions": {
+            "app_name": "The name of the application to analyze",
+            "cluster_name": "The name of the ECS cluster",
+            "task_id": "Specific task ID to retrieve logs for",
+            "time_window": "Time window in seconds to look back for logs (default: 3600)",
+            "filter_pattern": "CloudWatch logs filter pattern",
+            "start_time": "Explicit start time for the analysis window (UTC, takes precedence over time_window if provided)",
+            "end_time": "Explicit end time for the analysis window (UTC, defaults to current time if not provided)"
+        },
+        "example": 'action="fetch_task_logs", parameters={"cluster_name": "my-cluster", "filter_pattern": "ERROR", "time_window": 1800}'
+    },
+    "detect_image_pull_failures": {
+        "func": detect_image_pull_failures,
+        "required_params": ["app_name"],
+        "optional_params": [],
+        "transformer": lambda app_name, params: {
+            "app_name": app_name
+        },
+        "description": "Specialized tool for detecting container image pull failures",
+        "param_descriptions": {
+            "app_name": "Application name to check for image pull failures"
+        },
+        "example": 'action="detect_image_pull_failures", parameters={}'
+    }
+}
+
+
+def generate_troubleshooting_docs():
+    """Generate documentation for the troubleshooting tools based on the ACTIONS dictionary."""
+    
+    # Generate the main body of the documentation
+    actions_docs = []
+    quick_usage_examples = []
+    
+    for action_name, action_data in ACTIONS.items():
+        # Build the action documentation
+        action_doc = f"### {len(actions_docs) + 1}. {action_name}\n"
+        action_doc += f"{action_data['description']}\n"
+        
+        # Required parameters
+        action_doc += "- Required: " + ", ".join(action_data['required_params']) + "\n"
+        
+        # Optional parameters if any
+        if action_data.get('optional_params'):
+            optional_params_with_desc = []
+            for param in action_data.get('optional_params', []):
+                desc = action_data['param_descriptions'].get(param, "")
+                optional_params_with_desc.append(f"{param} ({desc})")
+            if optional_params_with_desc:
+                action_doc += "- Optional: " + ", ".join(optional_params_with_desc) + "\n"
+        
+        # Example usage
+        action_doc += f"- Example: {action_data['example']}\n"
+        
+        actions_docs.append(action_doc)
+        
+        # Build a quick usage example
+        example = f"# {action_data['description']}\n"
+        example += f'action: "{action_name}"\n'
+        
+        # Extract parameters from the example string
+        import re
+        params_match = re.search(r'parameters=\{(.*?)\}', action_data['example'])
+        if params_match:
+            params_str = params_match.group(1)
+            example += f"parameters: {{{params_str}}}\n"
+        else:
+            example += "parameters: {}\n"
+            
+        quick_usage_examples.append(example)
+    
+    # Combine all documentation sections
+    doc_header = """
+Consolidated ECS troubleshooting tool with multiple diagnostic actions.
+
+This tool provides access to all ECS troubleshooting operations through a single
+interface. Use the 'action' parameter to specify which troubleshooting operation
+to perform.
+
+## Available Actions and Parameters:
+
+"""
+    
+    doc_examples = """
+## Quick Usage Examples:
+
+```
+"""
+    
+    doc_footer = """```
+
+Parameters:
+    app_name: Application/stack name (required for most actions)
+    action: The troubleshooting action to perform (see available actions above)
+    parameters: Action-specific parameters (see parameter specifications above)
+
+Returns:
+    Results from the selected troubleshooting action
+"""
+    
+    # Combine all the documentation parts
+    full_doc = (
+        doc_header +
+        "\n".join(actions_docs) +
+        doc_examples +
+        "\n".join(quick_usage_examples) +
+        doc_footer
+    )
+    
+    return full_doc
+
+
+def _validate_action(action: str) -> None:
+    """Validate that the action is supported."""
+    if action not in ACTIONS:
+        valid_actions = ", ".join(ACTIONS.keys())
+        raise ValueError(f"Invalid action '{action}'. Valid actions: {valid_actions}")
+
+
+def _validate_parameters(action: str, app_name: Optional[str], parameters: Dict[str, Any]) -> None:
+    """Validate required parameters for the given action."""
+    required = ACTIONS[action]["required_params"]
+    
+    # Check app_name if required
+    if "app_name" in required and (not app_name or not app_name.strip()):
+        raise ValueError(f"app_name is required for action '{action}'")
+    
+    # Check other required parameters
+    for param in required:
+        if param != "app_name" and param not in parameters:
+            raise ValueError(f"Missing required parameter '{param}' for action '{action}'")
+
+
+# Pre-generate the documentation once to avoid regenerating it on each call
+TROUBLESHOOTING_DOCS = generate_troubleshooting_docs()
+
+def ecs_troubleshooting_tool(
+    app_name: Optional[str] = None,
+    action: TroubleshootingAction = "get_ecs_troubleshooting_guidance",
+    parameters: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
+    """
+    Consolidated ECS troubleshooting tool.
+    
+    This tool provides access to all ECS troubleshooting operations through a single
+    interface. Use the 'action' parameter to specify which troubleshooting operation
+    to perform.
+    
+    Args:
+        app_name: Application/stack name (required for most actions)
+        action: The troubleshooting action to perform
+        parameters: Action-specific parameters
+        
+    Returns:
+        Results from the selected troubleshooting action
+        
+    Raises:
+        ValueError: If action is invalid or required parameters are missing
+    """
+    # NOTE: The full documentation is available in the TROUBLESHOOTING_DOCS variable
+    try:
+        if parameters is None:
+            parameters = {}
+        
+        # Validate action
+        _validate_action(action)
+        
+        # Validate parameters
+        _validate_parameters(action, app_name, parameters)
+        
+        # Get action configuration
+        action_config = ACTIONS[action]
+        
+        # Transform parameters using action-specific transformer
+        func_params = action_config["transformer"](app_name, parameters)
+        
+        # Call the function
+        result = action_config["func"](**func_params)
+        
+        return result
+        
+    except ValueError as e:
+        logger.error(f"Parameter validation error: {str(e)}")
+        return {
+            "status": "error",
+            "error": str(e)
+        }
+    except Exception as e:
+        logger.exception(f"Error in ecs_troubleshooting_tool: {str(e)}")
+        return {
+            "status": "error",
+            "error": f"Internal error: {str(e)}"
+        }

--- a/src/ecs-mcp-server/awslabs/ecs_mcp_server/api/troubleshooting_tools/__init__.py
+++ b/src/ecs-mcp-server/awslabs/ecs_mcp_server/api/troubleshooting_tools/__init__.py
@@ -1,22 +1,21 @@
 """
-Troubleshooting tools for ECS deployments.
+ECS troubleshooting tools for MCP server.
 
-This module provides functions for diagnosing and troubleshooting issues with
-ECS applications deployed using AWS CloudFormation.
+This module provides tools for troubleshooting ECS deployments.
 """
 
-# Core diagnostic tools
-from awslabs.ecs_mcp_server.api.troubleshooting_tools.get_ecs_troubleshooting_guidance import get_ecs_troubleshooting_guidance
-from awslabs.ecs_mcp_server.api.troubleshooting_tools.fetch_cloudformation_status import fetch_cloudformation_status
-from awslabs.ecs_mcp_server.api.troubleshooting_tools.fetch_service_events import fetch_service_events
-from awslabs.ecs_mcp_server.api.troubleshooting_tools.fetch_task_failures import fetch_task_failures
-from awslabs.ecs_mcp_server.api.troubleshooting_tools.fetch_task_logs import fetch_task_logs
+from .get_ecs_troubleshooting_guidance import get_ecs_troubleshooting_guidance
+from .fetch_cloudformation_status import fetch_cloudformation_status
+from .fetch_service_events import fetch_service_events
+from .fetch_task_failures import fetch_task_failures
+from .fetch_task_logs import fetch_task_logs
+from .detect_image_pull_failures import detect_image_pull_failures
 
 __all__ = [
-    # Core diagnostic tools
     'get_ecs_troubleshooting_guidance',
     'fetch_cloudformation_status',
     'fetch_service_events',
     'fetch_task_failures',
     'fetch_task_logs',
+    'detect_image_pull_failures'
 ]

--- a/src/ecs-mcp-server/awslabs/ecs_mcp_server/api/troubleshooting_tools/detect_image_pull_failures.py
+++ b/src/ecs-mcp-server/awslabs/ecs_mcp_server/api/troubleshooting_tools/detect_image_pull_failures.py
@@ -11,8 +11,8 @@ import boto3
 from botocore.exceptions import ClientError
 
 from awslabs.ecs_mcp_server.api.troubleshooting_tools.get_ecs_troubleshooting_guidance import (
-    find_related_task_definitions,
-    check_container_images,
+    get_task_definitions,
+    validate_container_images,
 )
 
 logger = logging.getLogger(__name__)
@@ -41,7 +41,7 @@ def detect_image_pull_failures(app_name: str) -> Dict[str, Any]:
         }
         
         # Find related task definitions
-        task_definitions = find_related_task_definitions(app_name)
+        task_definitions = get_task_definitions(app_name)
         
         if not task_definitions:
             response["assessment"] = f"No task definitions found related to {app_name}"
@@ -49,7 +49,7 @@ def detect_image_pull_failures(app_name: str) -> Dict[str, Any]:
             return response
             
         # Check container images
-        image_results = check_container_images(task_definitions)
+        image_results = validate_container_images(task_definitions)
         
         # Analyze results
         failed_images = [result for result in image_results if result['exists'] != 'true']

--- a/src/ecs-mcp-server/awslabs/ecs_mcp_server/api/troubleshooting_tools/fetch_task_failures.py
+++ b/src/ecs-mcp-server/awslabs/ecs_mcp_server/api/troubleshooting_tools/fetch_task_failures.py
@@ -10,6 +10,7 @@ import datetime
 from typing import Dict, Any, Optional
 import boto3
 from botocore.exceptions import ClientError
+from awslabs.ecs_mcp_server.utils.time_utils import calculate_time_window
 
 logger = logging.getLogger(__name__)
 
@@ -43,26 +44,8 @@ def fetch_task_failures(
         Failed tasks with timestamps, exit codes, status, and resource utilization
     """
     try:            
-        # Determine the time range based on provided parameters
-        now = datetime.datetime.now(datetime.timezone.utc)
-        
-        # Handle provided start_time and end_time
-        if end_time is None:
-            # If no end_time provided, use current time
-            actual_end_time = now
-        else:
-            # Ensure end_time is timezone-aware
-            actual_end_time = end_time if end_time.tzinfo else end_time.replace(tzinfo=datetime.timezone.utc)
-        
-        if start_time is not None:
-            # If start_time provided, use it directly
-            actual_start_time = start_time if start_time.tzinfo else start_time.replace(tzinfo=datetime.timezone.utc)
-        elif end_time is not None:
-            # If only end_time provided, calculate start_time using time_window
-            actual_start_time = actual_end_time - datetime.timedelta(seconds=time_window)
-        else:
-            # Default case: use time_window from now
-            actual_start_time = now - datetime.timedelta(seconds=time_window)
+        # Calculate time window
+        actual_start_time, actual_end_time = calculate_time_window(time_window, start_time, end_time)
         
         response = {
             "status": "success",
@@ -179,16 +162,6 @@ def fetch_task_failures(
                         response["failure_categories"][category].append(task_failure)
                 
                 response["failed_tasks"].append(task_failure)
-            
-            # Get CloudWatch metrics for any failed tasks
-            if response["failed_tasks"]:
-                try:
-                    cloudwatch = boto3.client('cloudwatch')
-                    # We'll skip the actual implementation for brevity
-                    # This would query CloudWatch metrics for CPU/memory usage near failure time
-                    response["cloudwatch_metrics"] = "Metrics retrieval skipped for brevity"
-                except ClientError as cw_error:
-                    response["cloudwatch_error"] = str(cw_error)
             
         except ClientError as e:
             response["ecs_error"] = str(e)

--- a/src/ecs-mcp-server/awslabs/ecs_mcp_server/api/troubleshooting_tools/fetch_task_logs.py
+++ b/src/ecs-mcp-server/awslabs/ecs_mcp_server/api/troubleshooting_tools/fetch_task_logs.py
@@ -10,6 +10,7 @@ import datetime
 from typing import Dict, Any, Optional
 import boto3
 from botocore.exceptions import ClientError
+from awslabs.ecs_mcp_server.utils.time_utils import calculate_time_window
 
 logger = logging.getLogger(__name__)
 
@@ -49,26 +50,8 @@ def fetch_task_logs(
         Log entries with severity markers, highlighted errors, context
     """
     try:            
-        # Determine the time range based on provided parameters
-        now = datetime.datetime.now(datetime.timezone.utc)
-        
-        # Handle provided start_time and end_time
-        if end_time is None:
-            # If no end_time provided, use current time
-            actual_end_time = now
-        else:
-            # Ensure end_time is timezone-aware
-            actual_end_time = end_time if end_time.tzinfo else end_time.replace(tzinfo=datetime.timezone.utc)
-        
-        if start_time is not None:
-            # If start_time provided, use it directly
-            actual_start_time = start_time if start_time.tzinfo else start_time.replace(tzinfo=datetime.timezone.utc)
-        elif end_time is not None:
-            # If only end_time provided, calculate start_time using time_window
-            actual_start_time = actual_end_time - datetime.timedelta(seconds=time_window)
-        else:
-            # Default case: use time_window from now
-            actual_start_time = now - datetime.timedelta(seconds=time_window)
+        # Calculate time window
+        actual_start_time, actual_end_time = calculate_time_window(time_window, start_time, end_time)
         
         response = {
             "status": "success",

--- a/src/ecs-mcp-server/awslabs/ecs_mcp_server/api/troubleshooting_tools/get_ecs_troubleshooting_guidance.py
+++ b/src/ecs-mcp-server/awslabs/ecs_mcp_server/api/troubleshooting_tools/get_ecs_troubleshooting_guidance.py
@@ -7,237 +7,391 @@ for troubleshooting ECS deployments.
 
 import logging
 import datetime
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, Optional, List, Tuple
 import boto3
 from botocore.exceptions import ClientError
 
-from awslabs.ecs_mcp_server.utils.arn_parser import parse_arn, get_resource_name
+from awslabs.ecs_mcp_server.utils.arn_parser import parse_arn
 
 logger = logging.getLogger(__name__)
 
-def find_related_resources(app_name: str) -> Dict[str, Any]:
-    """
-    Find resources with similar naming patterns to the app_name.
-    
-    This addresses the issue where resources might exist but not be directly
-    associated with a CloudFormation stack.
-    """
-    result = {
-        "clusters": [],
-        "services": [],
-        "task_definitions": [],
-        "load_balancers": []
-    }
-    
-    # Look for clusters with similar names
+
+def handle_aws_api_call(func, error_value=None, *args, **kwargs):
+    """Execute AWS API calls with standardized error handling."""
+    try:
+        return func(*args, **kwargs)
+    except ClientError as e:
+        logger.warning(f"API error in {func.__name__ if hasattr(func, '__name__') else 'unknown'}: {e}")
+        return error_value
+    except Exception as e:
+        logger.exception(f"Unexpected error in {func.__name__ if hasattr(func, '__name__') else 'unknown'}: {e}")
+        return error_value
+
+
+def find_clusters(app_name: str) -> List[str]:
+    """Find ECS clusters related to the application."""
+    clusters = []
     ecs = boto3.client('ecs')
-    try:
-        clusters = ecs.list_clusters()
-        for cluster_arn in clusters['clusterArns']:
-            parsed_arn = parse_arn(cluster_arn)
-            if parsed_arn:
-                cluster_name = parsed_arn.resource_name
-                if app_name.lower() in cluster_name.lower():
-                    result['clusters'].append(cluster_name)
-                    
-                    # Look for services in this cluster
-                    try:
-                        services = ecs.list_services(cluster=cluster_name)
-                        # Ensure we have a valid response with serviceArns
-                        if isinstance(services, dict) and 'serviceArns' in services:
-                            for service_arn in services['serviceArns']:
-                                parsed_service_arn = parse_arn(service_arn)
-                                if parsed_service_arn:
-                                    service_name = parsed_service_arn.resource_name
-                                    if app_name.lower() in service_name.lower():
-                                        result['services'].append(service_name)
-                    except (ClientError, TypeError, KeyError):
-                        pass
-    except ClientError:
-        pass
+    
+    cluster_list = handle_aws_api_call(ecs.list_clusters, {"clusterArns": []})
+    if not cluster_list or "clusterArns" not in cluster_list:
+        return clusters
         
-    # Also check the default cluster for services
-    try:
-        default_services = ecs.list_services(cluster='default')
-        # Ensure we have a valid response with serviceArns
-        if isinstance(default_services, dict) and 'serviceArns' in default_services:
-            for service_arn in default_services['serviceArns']:
-                parsed_service_arn = parse_arn(service_arn)
-                if parsed_service_arn:
-                    service_name = parsed_service_arn.resource_name
-                    if app_name.lower() in service_name.lower():
-                        result['services'].append(service_name)
-    except (ClientError, TypeError, KeyError):
-        pass
+    for cluster_arn in cluster_list["clusterArns"]:
+        parsed_arn = parse_arn(cluster_arn)
+        if parsed_arn and app_name.lower() in parsed_arn.resource_name.lower():
+            clusters.append(parsed_arn.resource_name)
     
-    # Get task definitions using the comprehensive function
-    task_definitions = find_related_task_definitions(app_name)
-    for task_def in task_definitions:
-        if 'taskDefinitionArn' in task_def:
-            parsed_arn = parse_arn(task_def['taskDefinitionArn'])
-            if parsed_arn:
-                result['task_definitions'].append(parsed_arn.resource_id)
+    return clusters
+
+
+def find_services(app_name: str, cluster_name: str) -> List[str]:
+    """Find ECS services in a specific cluster related to the application."""
+    services = []
+    ecs = boto3.client('ecs')
     
-    # Also check for directly matching task definition names from list_task_definitions (for test cases)
     try:
-        list_result = ecs.list_task_definitions()
-        # Handle both real API responses and mock objects in tests
-        task_def_arns = []
-        if isinstance(list_result, dict) and 'taskDefinitionArns' in list_result:
-            task_def_arns = list_result['taskDefinitionArns']
+        service_list = ecs.list_services(cluster=cluster_name)
+        
+        if not isinstance(service_list, dict):
+            return services
+
+        if not service_list or "serviceArns" not in service_list:
+            return services
             
-        for arn in task_def_arns:
-            parsed_arn = parse_arn(arn)
+        for service_arn in service_list["serviceArns"]:
+            parsed_arn = parse_arn(service_arn)
             if parsed_arn and app_name.lower() in parsed_arn.resource_name.lower():
-                result['task_definitions'].append(parsed_arn.resource_id)
-    except (ClientError, TypeError):
-        pass
+                services.append(parsed_arn.resource_name)
+    except Exception as e:
+        logger.warning(f"Error listing services for cluster {cluster_name}: {e}")
     
-    # Look for load balancers with similar names
+    return services
+
+
+def find_load_balancers(app_name: str) -> List[Dict[str, Any]]:
+    """Find load balancers related to the application."""
+    load_balancers = []
     elbv2 = boto3.client('elbv2')
-    try:
-        lbs = elbv2.describe_load_balancers()
-        for lb in lbs['LoadBalancers']:
-            if app_name.lower() in lb['LoadBalancerName'].lower():
-                result['load_balancers'].append(lb['LoadBalancerName'])
-    except ClientError:
-        pass
     
-    return result
+    lb_list = handle_aws_api_call(
+        elbv2.describe_load_balancers,
+        {"LoadBalancers": []}
+    )
+    
+    if not lb_list or "LoadBalancers" not in lb_list:
+        return load_balancers
+        
+    for lb in lb_list["LoadBalancers"]:
+        if app_name.lower() in lb.get("LoadBalancerName", "").lower():
+            load_balancers.append(lb.get("LoadBalancerName"))
+    
+    return load_balancers
 
 
-def find_related_task_definitions(app_name: str) -> list:
+def get_task_definitions(app_name: str) -> List[Dict[str, Any]]:
     """
-    Find task definitions related to the app_name.
+    Find task definitions related to the application using simple name matching.
+    
+    This function retrieves all task definition families matching the app name pattern,
+    then gets the latest revision of each family to return complete task definition objects.
+    
+    Parameters
+    ----------
+    app_name : str
+        The name of the application to find task definitions for
+
+    Returns
+    -------
+    List[Dict[str, Any]]
+        List of task definition dictionaries with full details
     """
     task_definitions = []
     ecs = boto3.client('ecs')
+    app_name_lower = app_name.lower()
     
     try:
-        # Get all task definition families that might be related
-        families = ecs.list_task_definition_families(
-            familyPrefix=app_name,
-            status='ACTIVE'
-        )
+        # Get list of task definition ARNs
+        paginator = ecs.get_paginator('list_task_definitions')
+        families_by_latest = {}
         
-        # Also try some common naming patterns
-        variations = [
-            app_name,
-            f"{app_name}-task",
-            f"{app_name}-service",
-            f"{app_name}-container",
-            f"task-{app_name}",
-            f"service-{app_name}",
-            f"failing-task-def-{app_name.split('-')[-1]}" if '-' in app_name else ""
-        ]
-        
-        # Get the latest task definition for each family
-        for family in families['families'] + variations:
-            if not family:
-                continue
+        # Use pagination to handle large lists efficiently
+        for page in paginator.paginate(status='ACTIVE', maxResults=100):
+            for arn in page.get('taskDefinitionArns', []):
+                parsed_arn = parse_arn(arn)
+                if not parsed_arn:
+                    continue
                 
-            try:
-                task_defs = ecs.list_task_definitions(
-                    familyPrefix=family,
-                    status='ACTIVE',
-                    sort='DESC',
-                    maxResults=1
-                )
+                # Extract family and revision directly using the parsed ARN
+                resource_parts = parsed_arn.resource_id.split(':')
+                family = resource_parts[0]
+                revision = int(resource_parts[1]) if len(resource_parts) > 1 else 0
                 
-                if task_defs['taskDefinitionArns']:
-                    # Get full task definition details
-                    task_def = ecs.describe_task_definition(
-                        taskDefinition=task_defs['taskDefinitionArns'][0]
-                    )
-                    task_definitions.append(task_def['taskDefinition'])
-            except ClientError:
-                continue
-    except ClientError:
-        pass
+                # Check if app name is in the family name
+                if app_name_lower in family.lower():
+                    # Track only the latest revision
+                    if family not in families_by_latest or revision > families_by_latest[family][1]:
+                        families_by_latest[family] = (arn, revision)
         
+        # Get task definitions for the latest revision of each matching family
+        for arn, _ in families_by_latest.values():
+            task_def_response = handle_aws_api_call(
+                ecs.describe_task_definition,
+                None,
+                taskDefinition=arn
+            )
+            if task_def_response and "taskDefinition" in task_def_response:
+                task_definitions.append(task_def_response["taskDefinition"])
+                
+    except ClientError as e:
+        logger.warning(f"Error finding task definitions: {e}")
+    except Exception as e:
+        logger.warning(f"Unexpected error finding task definitions: {e}")
+    
     return task_definitions
 
 
-def check_container_images(task_definitions: list) -> list:
+def discover_resources(app_name: str) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
     """
-    Check if container images in task definitions exist and are accessible.
+    Main resource discovery coordinator function.
     
-    This specifically helps with diagnosing image pull failures.
+    Discovers all ECS resources related to the given application name including
+    clusters, services, task definitions, and load balancers.
+    
+    Parameters
+    ----------
+    app_name : str
+        The name of the application to discover resources for
+        
+    Returns
+    -------
+    Tuple[Dict[str, Any], List[Dict[str, Any]]]
+        Tuple containing:
+        - Dictionary of resource IDs grouped by type
+        - List of complete task definition objects
     """
+    resources = {
+        "clusters": find_clusters(app_name),
+        "services": [],
+        "task_definitions": [],
+        "load_balancers": find_load_balancers(app_name)
+    }
+    
+    # Find services for each discovered cluster and default cluster
+    for cluster in resources["clusters"] + ["default"]:
+        services = find_services(app_name, cluster)
+        resources["services"].extend(services)
+    
+    # Get task definitions
+    task_defs = get_task_definitions(app_name)
+    
+    # For task definitions, extract and format the resource ID
+    for task_def in task_defs:
+        if "taskDefinitionArn" in task_def:
+            parsed_arn = parse_arn(task_def["taskDefinitionArn"])
+            if parsed_arn:
+                resources["task_definitions"].append(parsed_arn.resource_id)
+            
+    return resources, task_defs
+
+
+
+def is_ecr_image(image_uri: str) -> bool:
+    """Determine if an image is from ECR."""
+    return 'amazonaws.com' in image_uri and 'ecr' in image_uri
+
+
+def parse_ecr_image_uri(image_uri: str) -> Tuple[str, str]:
+    """Parse an ECR image URI into repository name and tag."""
+    try:
+        # Parse repository name and tag
+        if ':' in image_uri:
+            repo_uri, tag = image_uri.split(':', 1)
+        else:
+            repo_uri, tag = image_uri, 'latest'
+        
+        # Extract repository name from URI
+        if repo_uri.startswith('arn:'):
+            parsed_arn = parse_arn(repo_uri)
+            if parsed_arn:
+                repo_name = parsed_arn.resource_name
+            else:
+                repo_name = repo_uri.split('/')[-1]
+        else:
+            repo_name = repo_uri.split('/')[-1]
+            
+        return repo_name, tag
+    except Exception as e:
+        logger.error(f"Failed to parse ECR image URI {image_uri}: {e}")
+        return "", ""
+
+
+def validate_image(image_uri: str) -> Dict[str, Any]:
+    """
+    Validate if a container image exists and is accessible.
+    
+    A unified function that handles both ECR and external images.
+    
+    Parameters
+    ----------
+    image_uri : str
+        The container image URI to validate
+        
+    Returns
+    -------
+    Dict[str, Any]
+        Dictionary with validation results
+    """
+    # Initialize result structure
+    result = {
+        'image': image_uri,
+        'exists': 'false',
+        'error': None
+    }
+    
+    # Determine image type
+    if is_ecr_image(image_uri):
+        # ECR image logic
+        result['repository_type'] = 'ecr'
+        ecr = boto3.client('ecr')
+        
+        # Parse repository name and tag
+        repo_name, tag = parse_ecr_image_uri(image_uri)
+        if not repo_name:
+            result['error'] = "Failed to parse ECR image URI"
+            return result
+        
+        # Check if repository exists
+        try:
+            repo_check = ecr.describe_repositories(repositoryNames=[repo_name])
+            
+            # Check if image with tag exists
+            try:
+                image_check = ecr.describe_images(
+                    repositoryName=repo_name, 
+                    imageIds=[{'imageTag': tag}]
+                )
+                result['exists'] = 'true'
+            except ClientError as e:
+                if e.response['Error']['Code'] == 'ImageNotFoundException':
+                    result['error'] = f"Image with tag {tag} not found in repository {repo_name}"
+                else:
+                    result['error'] = str(e)
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'RepositoryNotFoundException':
+                result['error'] = f"Repository {repo_name} not found"
+            else:
+                result['error'] = str(e)
+        except Exception as e:
+            result['error'] = str(e)
+    else:
+        # External image logic (Docker Hub, etc.)
+        result['repository_type'] = 'external'
+        result['exists'] = 'unknown'  # We can't easily check these
+        
+    return result
+
+
+def validate_container_images(task_definitions: List[Dict]) -> List[Dict]:
+    """Validate container images in task definitions."""
     results = []
-    ecr = boto3.client('ecr')
     
     for task_def in task_definitions:
         for container in task_def.get('containerDefinitions', []):
             image = container.get('image', '')
-            result = {
-                'image': image,
-                'task_definition': task_def.get('taskDefinitionArn', ''),
-                'container_name': container.get('name', ''),
-                'exists': False,
-                'error': None,
-                'repository_type': 'unknown'
-            }
             
-            # Determine if it's an ECR image or external image
-            if 'amazonaws.com' in image and 'ecr' in image:
-                # ECR image
-                result['repository_type'] = 'ecr'
-                try:
-                    # Parse repository name and tag
-                    if ':' in image:
-                        repo_uri, tag = image.split(':', 1)
-                    else:
-                        repo_uri, tag = image, 'latest'
-                    
-                    # Extract repository name from URI using our ARN parser if it's an ARN
-                    if repo_uri.startswith('arn:'):
-                        parsed_arn = parse_arn(repo_uri)
-                        if parsed_arn:
-                            repo_name = parsed_arn.resource_name
-                        else:
-                            repo_name = repo_uri.split('/')[-1]
-                    else:
-                        # Not an ARN, but still try to extract repository name
-                        repo_name = repo_uri.split('/')[-1]
-                    
-                    # Check if repository exists
-                    try:
-                        ecr.describe_repositories(repositoryNames=[repo_name])
-                        
-                        # Check if image with tag exists
-                        try:
-                            ecr.describe_images(
-                                repositoryName=repo_name,
-                                imageIds=[{'imageTag': tag}]
-                            )
-                            result['exists'] = 'true'
-                        except ClientError as e:
-                            if 'ImageNotFound' in str(e):
-                                result['error'] = f"Image with tag {tag} not found in repository {repo_name}"
-                                result['exists'] = 'false'
-                            else:
-                                result['error'] = str(e)
-                                result['exists'] = 'false'
-                    except ClientError as e:
-                        if 'RepositoryNotFoundException' in str(e):
-                            result['error'] = f"Repository {repo_name} not found"
-                            result['exists'] = 'false'
-                        else:
-                            result['error'] = str(e)
-                            result['exists'] = 'false'
-                except Exception as e:
-                    result['error'] = f"Failed to parse ECR image: {str(e)}"
-                    result['exists'] = 'false'
-            else:
-                # External image (Docker Hub, etc.) - we can't easily check these
-                result['repository_type'] = 'external'
-                result['exists'] = 'unknown'
+            # Use the unified validate_image function
+            result = validate_image(image)
                 
+            # Add task and container context
+            result.update({
+                'task_definition': task_def.get('taskDefinitionArn', ''),
+                'container_name': container.get('name', '')
+            })
+            
             results.append(result)
     
     return results
 
+
+
+def get_stack_status(app_name: str) -> str:
+    """Get CloudFormation stack status for the application."""
+    cloudformation = boto3.client('cloudformation')
+    try:
+        cf_response = cloudformation.describe_stacks(StackName=app_name)
+        if cf_response["Stacks"]:
+            return cf_response["Stacks"][0]["StackStatus"]
+        return "NOT_FOUND"
+    except ClientError as e:
+        # Handle specific CloudFormation errors
+        if e.response['Error']['Code'] == 'AccessDenied':
+            # For AccessDenied (test case), this should propagate to the caller
+            # to be treated as an error
+            raise e
+        return "NOT_FOUND"
+
+
+def create_assessment(app_name: str, stack_status: str, resources: Dict) -> str:
+    """Create a human-readable assessment of the application's state."""
+    if stack_status == "NOT_FOUND":
+        assessment = f"CloudFormation stack '{app_name}' does not exist. Infrastructure deployment may have failed or not been attempted."
+        
+        # Add information about related resources if found
+        if resources["task_definitions"]:
+            assessment += f" Found {len(resources['task_definitions'])} related task definitions."
+        
+        if resources["clusters"]:
+            assessment += f" Found similar clusters that may be related: {', '.join(resources['clusters'])}."
+            
+    elif 'ROLLBACK' in stack_status or 'FAILED' in stack_status:
+        assessment = f"CloudFormation stack '{app_name}' exists but is in a failed state: {stack_status}."
+        
+    elif 'IN_PROGRESS' in stack_status:
+        assessment = f"CloudFormation stack '{app_name}' is currently being created/updated: {stack_status}."
+        
+    elif stack_status == 'CREATE_COMPLETE' and not resources["clusters"]:
+        assessment = f"CloudFormation stack '{app_name}' exists and is complete, but no related ECS clusters were found."
+        
+    elif stack_status == 'CREATE_COMPLETE' and resources["clusters"]:
+        cluster_name = resources["clusters"][0]
+        assessment = f"CloudFormation stack '{app_name}' and ECS cluster '{cluster_name}' both exist."
+        
+    else:
+        assessment = f"CloudFormation stack '{app_name}' is in status: {stack_status}."
+    
+    return assessment
+
+
+def get_cluster_details(cluster_names: List[str]) -> List[Dict[str, Any]]:
+    """Get detailed information about ECS clusters."""
+    if not cluster_names:
+        return []
+        
+    ecs = boto3.client('ecs')
+    clusters_info = handle_aws_api_call(
+        ecs.describe_clusters,
+        {"clusters": [], "failures": []},
+        clusters=cluster_names
+    )
+    
+    if not clusters_info or "clusters" not in clusters_info:
+        return []
+    
+    detailed_clusters = []
+    for cluster in clusters_info.get("clusters", []):
+        cluster_info = {
+            'name': cluster['clusterName'],
+            'status': cluster['status'],
+            'exists': True,
+            'runningTasksCount': cluster.get('runningTasksCount', 0),
+            'pendingTasksCount': cluster.get('pendingTasksCount', 0),
+            'activeServicesCount': cluster.get('activeServicesCount', 0),
+            'registeredContainerInstancesCount': cluster.get('registeredContainerInstancesCount', 0)
+        }
+        detailed_clusters.append(cluster_info)
+    
+    return detailed_clusters
 
 
 def get_ecs_troubleshooting_guidance(
@@ -245,7 +399,7 @@ def get_ecs_troubleshooting_guidance(
     symptoms_description: Optional[str] = None
 ) -> Dict[str, Any]:
     """
-    Initial entry point that analyzes symptoms and recommends specific diagnostic paths.
+    Initial entry point that analyzes ECS deployment state and collects troubleshooting information.
 
     Parameters
     ----------
@@ -257,240 +411,48 @@ def get_ecs_troubleshooting_guidance(
     Returns
     -------
     Dict[str, Any]
-        Diagnostic path recommendation, initial assessment, and detected symptoms
+        Initial assessment and collected troubleshooting data
     """
     try:
         # Initialize response structure
         response = {
             "status": "success",
-            "diagnostic_path": [],
             "assessment": "",
-            "detected_symptoms": {
-                "infrastructure": [],
-                "service": [],
-                "task": [],
-                "application": [],
-                "network": []
-            },
             "raw_data": {}
         }
         
-        # Search for related resources by naming pattern
-        related_resources = find_related_resources(app_name)
-        response['raw_data']['related_resources'] = related_resources
-        
-        # Look for task definitions even without a stack
-        task_definitions = find_related_task_definitions(app_name)
+        # 1. Discover resources and collect raw task definitions
+        resources, task_definitions = discover_resources(app_name)
+        response['raw_data']['related_resources'] = resources
         response['raw_data']['task_definitions'] = task_definitions
         
-        # Check container images in task definitions
-        image_check_results = check_container_images(task_definitions)
-        response['raw_data']['image_check_results'] = image_check_results
-
-        # Determine if the CloudFormation stack exists
-        cloudformation = boto3.client('cloudformation')
+        # 2. Get detailed cluster information
+        clusters = get_cluster_details(resources["clusters"])
+        response['raw_data']['clusters'] = clusters
+        
         try:
-            cf_response = cloudformation.describe_stacks(StackName=app_name)
-            stack_exists = True
-            stack_status = cf_response['Stacks'][0]['StackStatus']
+            # 3. Check stack status
+            stack_status = get_stack_status(app_name)
             response['raw_data']['cloudformation_status'] = stack_status
         except ClientError as e:
-            if "does not exist" in str(e):
-                stack_exists = False
-                stack_status = "NOT_FOUND"
-            else:
-                raise
-
-        # Determine if ECS clusters exist
-        ecs = boto3.client('ecs')
-        cluster_exists = False
-        cluster_name = None
+            # Handle auth error or other ClientError
+            error_msg = str(e)
+            response['status'] = "error"
+            response['error'] = error_msg
+            response['assessment'] = f"Error accessing stack information: {error_msg}"
+            return response
         
-        # Store comprehensive information about all related clusters
-        response['raw_data']['clusters'] = []
+        # 4. Check container images
+        image_check_results = validate_container_images(task_definitions)
+        response['raw_data']['image_check_results'] = image_check_results
         
-        if related_resources['clusters']:
-            try:
-                clusters = ecs.describe_clusters(clusters=related_resources['clusters'])
-                if clusters['clusters']:
-                    # Store detailed info for each cluster
-                    for cluster in clusters['clusters']:
-                        # Store each cluster's data in a comprehensive structure
-                        cluster_info = {
-                            'name': cluster['clusterName'],
-                            'status': cluster['status'],
-                            'exists': True,
-                            'runningTasksCount': cluster.get('runningTasksCount', 0),
-                            'pendingTasksCount': cluster.get('pendingTasksCount', 0),
-                            'activeServicesCount': cluster.get('activeServicesCount', 0),
-                            'registeredContainerInstancesCount': cluster.get('registeredContainerInstancesCount', 0)
-                        }
-                        response['raw_data']['clusters'].append(cluster_info)
-                    
-                    # For diagnostic purposes, use the first cluster found
-                    first_cluster = clusters['clusters'][0]
-                    cluster_exists = True
-                    cluster_name = first_cluster['clusterName']
-            except ClientError:
-                pass
-        
-        # Check if there are any clusters with similar name patterns
-        if not cluster_exists and related_resources['clusters']:
-            response['detected_symptoms']['infrastructure'].append(
-                f"Found similar clusters that may be related: {', '.join(related_resources['clusters'])}"
-            )
-
-        # Analyze provided symptoms if any
+        # Store symptoms description as raw input if provided
         if symptoms_description:
             response['raw_data']['symptoms_description'] = symptoms_description
-            
-            # Look for infrastructure-related symptoms
-            infra_keywords = ['stack', 'cloudformation', 'deploy', 'creation', 'infrastructure', 'rollback']
-            for keyword in infra_keywords:
-                if keyword.lower() in symptoms_description.lower():
-                    response['detected_symptoms']['infrastructure'].append(f"Mentioned '{keyword}'")
-            
-            # Look for service-related symptoms
-            service_keywords = ['service', 'deployment', 'unstable', 'events']
-            for keyword in service_keywords:
-                if keyword.lower() in symptoms_description.lower():
-                    response['detected_symptoms']['service'].append(f"Mentioned '{keyword}'")
-            
-            # Look for task-related symptoms
-            task_keywords = ['task', 'container', 'failing', 'crash', 'exit', 'restart', 'image', 'pull']
-            for keyword in task_keywords:
-                if keyword.lower() in symptoms_description.lower():
-                    response['detected_symptoms']['task'].append(f"Mentioned '{keyword}'")
-            
-            # Look for application-related symptoms
-            app_keywords = ['error', 'exception', 'log', 'application', 'code', 'bug']
-            for keyword in app_keywords:
-                if keyword.lower() in symptoms_description.lower():
-                    response['detected_symptoms']['application'].append(f"Mentioned '{keyword}'")
-            
-            # Look for network-related symptoms
-            network_keywords = ['network', 'connection', 'unreachable', 'timeout', 'load balancer']
-            for keyword in network_keywords:
-                if keyword.lower() in symptoms_description.lower():
-                    response['detected_symptoms']['network'].append(f"Mentioned '{keyword}'")
-                    
-        # Check for potential image pull failures
-        has_image_issues = any(result['exists'] != 'true' for result in image_check_results)
-        if has_image_issues:
-            response['detected_symptoms']['task'].append("Potential container image pull failure detected")
-            
-            # Extract failing image names
-            failing_images = [result['image'] for result in image_check_results if result['exists'] != 'true']
-            if failing_images:
-                response['detected_symptoms']['task'].append(
-                    f"Invalid container image references: {', '.join(failing_images)}"
-                )
-
-        # Create diagnostic path based on stack and cluster existence/status
-        if not stack_exists:
-            response['assessment'] = f"CloudFormation stack '{app_name}' does not exist. Infrastructure deployment may have failed or not been attempted."
-            
-            # If related task definitions found, check for image issues
-            if task_definitions:
-                response['assessment'] += f" Found {len(task_definitions)} related task definitions."
-                
-                # If image issues detected, prioritize that diagnostic path
-                if has_image_issues:
-                    response['assessment'] += " Potential container image issues detected."
-                    response['diagnostic_path'].insert(0, {
-                        "tool": "detect_image_pull_failures",
-                        "args": {"app_name": app_name},
-                        "reason": "Check for container image pull failures"
-                    })
-            
-            # Existing recommendation
-            response['diagnostic_path'].append({
-                "tool": "fetch_cloudformation_status",
-                "args": {"stack_id": app_name},
-                "reason": "Check if any stack with this name exists in other states"
-            })
-            
-            # If we found related resources, suggest checking them
-            if related_resources['clusters']:
-                response['diagnostic_path'].append({
-                    "tool": "ecs_resource_management",
-                    "args": {
-                        "action": "describe", 
-                        "resource_type": "cluster",
-                        "identifier": related_resources['clusters'][0]
-                    },
-                    "reason": f"Check related cluster: {related_resources['clusters'][0]}"
-                })
-            
-        elif 'ROLLBACK' in stack_status or 'FAILED' in stack_status:
-            response['assessment'] = f"CloudFormation stack '{app_name}' exists but is in a failed state: {stack_status}."
-            response['diagnostic_path'].append({
-                "tool": "fetch_cloudformation_status",
-                "args": {"stack_id": app_name},
-                "reason": "Analyze stack failure events to determine root cause"
-            })
-            
-            # Check for image issues if detected
-            if has_image_issues:
-                response['diagnostic_path'].append({
-                    "tool": "detect_image_pull_failures",
-                    "args": {"app_name": app_name},
-                    "reason": "Check for container image pull failures that may have caused stack creation failure"
-                })
-                
-        elif 'IN_PROGRESS' in stack_status:
-            response['assessment'] = f"CloudFormation stack '{app_name}' is currently being created/updated: {stack_status}."
-            response['diagnostic_path'].append({
-                "tool": "fetch_cloudformation_status",
-                "args": {"stack_id": app_name},
-                "reason": "Monitor stack creation/update progress"
-            })
-            if cluster_exists:
-                response['diagnostic_path'].append({
-                    "tool": "fetch_task_failures",
-                    "args": {"app_name": app_name, "cluster_name": cluster_name, "time_window": 3600},
-                    "reason": "Check for task failures during deployment"
-                })
-        elif stack_status == 'CREATE_COMPLETE' and not cluster_exists:
-            response['assessment'] = f"CloudFormation stack '{app_name}' exists and is complete, but ECS cluster '{cluster_name}' was not found."
-            response['diagnostic_path'].append({
-                "tool": "fetch_cloudformation_status",
-                "args": {"stack_id": app_name},
-                "reason": "Verify stack resources were properly created"
-            })
-        elif stack_status == 'CREATE_COMPLETE' and cluster_exists:
-            # Stack and cluster exist, so we need to check service and task status
-            response['assessment'] = f"CloudFormation stack '{app_name}' and ECS cluster '{cluster_name}' both exist."
-            
-            # If image issues detected, prioritize that diagnostic path
-            if has_image_issues:
-                response['diagnostic_path'].append({
-                    "tool": "detect_image_pull_failures",
-                    "args": {"app_name": app_name},
-                    "reason": "Check for container image pull failures"
-                })
-            
-            # Check for task failures first
-            response['diagnostic_path'].append({
-                "tool": "fetch_task_failures",
-                "args": {"app_name": app_name, "cluster_name": cluster_name, "time_window": 3600},
-                "reason": "Check for recent task failures"
-            })
-            
-            # Then check service events
-            response['diagnostic_path'].append({
-                "tool": "fetch_service_events",
-                "args": {"app_name": app_name, "cluster_name": cluster_name, "service_name": app_name, "time_window": 3600},
-                "reason": "Analyze service events for issues"
-            })
-            
-            # Finally check logs
-            response['diagnostic_path'].append({
-                "tool": "fetch_task_logs",
-                "args": {"app_name": app_name, "cluster_name": cluster_name, "time_window": 3600},
-                "reason": "Analyze application logs for errors"
-            })
-
+        
+        # Create assessment
+        response['assessment'] = create_assessment(app_name, stack_status, resources)
+        
         return response
 
     except Exception as e:
@@ -498,7 +460,5 @@ def get_ecs_troubleshooting_guidance(
         return {
             "status": "error",
             "error": str(e),
-            "diagnostic_path": [],
-            "assessment": f"Error analyzing deployment: {str(e)}",
-            "detected_symptoms": {}
+            "assessment": f"Error analyzing deployment: {str(e)}"
         }

--- a/src/ecs-mcp-server/awslabs/ecs_mcp_server/modules/deployment_status.py
+++ b/src/ecs-mcp-server/awslabs/ecs_mcp_server/modules/deployment_status.py
@@ -23,6 +23,14 @@ def register_module(mcp: FastMCP) -> None:
             default=None,
             description="Name of the ECS cluster",
         ),
+        stack_name: Optional[str] = Field(
+            default=None,
+            description="Name of the CloudFormation stack (optional, defaults to {app_name}-ecs-infrastructure)",
+        ),
+        service_name: Optional[str] = Field(
+            default=None,
+            description="Name of the ECS service (optional, defaults to {app_name}-service)",
+        ),
     ) -> Dict[str, Any]:
         """
         Gets the status of an ECS deployment and returns the ALB URL.
@@ -34,7 +42,9 @@ def register_module(mcp: FastMCP) -> None:
         USAGE INSTRUCTIONS:
         1. Provide the name of your application
         2. Optionally specify the cluster name if different from the application name
-        3. The tool will return the deployment status and access URL once the deployment is complete.
+        3. Optionally specify the stack name if different from the default naming convention
+        4. Optionally specify the service name if different from the default naming pattern
+        5. The tool will return the deployment status and access URL once the deployment is complete.
 
         Poll this tool every 30 seconds till the status is active.
 
@@ -50,8 +60,10 @@ def register_module(mcp: FastMCP) -> None:
         Parameters:
             app_name: Name of the application
             cluster_name: Name of the ECS cluster (optional, defaults to app_name)
+            stack_name: Name of the CloudFormation stack (optional, defaults to {app_name}-ecs-infrastructure)
+            service_name: Name of the ECS service (optional, defaults to {app_name}-service)
 
         Returns:
             Dictionary containing deployment status and ALB URL
         """
-        return await get_deployment_status(app_name, cluster_name)
+        return await get_deployment_status(app_name, cluster_name, stack_name, service_name)

--- a/src/ecs-mcp-server/awslabs/ecs_mcp_server/modules/troubleshooting.py
+++ b/src/ecs-mcp-server/awslabs/ecs_mcp_server/modules/troubleshooting.py
@@ -2,508 +2,123 @@
 Troubleshooting module for ECS MCP Server.
 This module provides tools and prompts for troubleshooting ECS deployments.
 """
-import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 
-from awslabs.ecs_mcp_server.api.troubleshooting_tools import (
-    get_ecs_troubleshooting_guidance,
-    fetch_cloudformation_status,
-    fetch_service_events,
-    fetch_task_failures,
-    fetch_task_logs,
+from awslabs.ecs_mcp_server.api.ecs_troubleshooting import (
+    ecs_troubleshooting_tool,
+    TROUBLESHOOTING_DOCS
 )
-from awslabs.ecs_mcp_server.api.troubleshooting_tools.detect_image_pull_failures import (
-    detect_image_pull_failures,
-)
+
+
+def register_troubleshooting_prompts(mcp: FastMCP, prompt_groups: Dict[str, List[str]]) -> None:
+    """
+    Register multiple prompt patterns that all return the same tool.
+    
+    Args:
+        mcp: FastMCP instance
+        prompt_groups: Dict mapping descriptions to pattern lists
+    """
+    for description, patterns in prompt_groups.items():
+        for pattern in patterns:
+            def create_handler(pattern_val: str, desc: str):
+                def prompt_handler():
+                    return ["ecs_troubleshooting_tool"]
+                
+                # Create a valid function name from the pattern
+                safe_name = pattern_val.replace(' ', '_').replace('.*', 'any').replace("'", '').replace('"', '')
+                safe_name = ''.join(c if c.isalnum() or c == '_' else '_' for c in safe_name)
+                prompt_handler.__name__ = f"{safe_name}_prompt"
+                prompt_handler.__doc__ = desc
+                return prompt_handler
+            
+            mcp.prompt(pattern)(create_handler(pattern, description))
 
 
 def register_module(mcp: FastMCP) -> None:
     """Register troubleshooting module tools and prompts with the MCP server."""
     
-    @mcp.tool(name="get_ecs_troubleshooting_guidance")
-    async def mcp_get_ecs_troubleshooting_guidance(
-        app_name: str = Field(
-            ...,
-            description="The name of the application/stack to troubleshoot",
-        ),
-        symptoms_description: Optional[str] = Field(
+    @mcp.tool(
+        name="ecs_troubleshooting_tool",
+        description=TROUBLESHOOTING_DOCS # Dynamically generated documentation string
+    )
+    async def mcp_ecs_troubleshooting_tool(
+        app_name: Optional[str] = Field(
             default=None,
-            description="Description of symptoms experienced by the user",
+            description="Application/stack name (required for most actions)",
+        ),
+        action: str = Field(
+            ...,
+            description="Troubleshooting action to perform",
+        ),
+        parameters: Optional[Dict[str, Any]] = Field(
+            default_factory=dict,
+            description="Action-specific parameters",
         ),
     ) -> Dict[str, Any]:
-        """
-        Initial entry point that analyzes symptoms and recommends specific diagnostic paths.
+        return ecs_troubleshooting_tool(app_name, action, parameters)
 
-        This tool serves as the starting point for troubleshooting ECS deployments by analyzing
-        symptoms and recommending specific diagnostic tools to use next. It examines the state
-        of your deployment and creates a guided troubleshooting plan.
-        
-        IMPORTANT USAGE GUIDELINES:
-        When this tool identifies a clear root cause such as:
-        - Invalid container image references
-        - Specific CloudFormation error messages 
-        - Missing required configuration parameters
-        
-        DO NOT use additional diagnostic tools unless they would provide new, relevant 
-        information not already discovered. Avoid redundant checks when a definitive cause is found.
-
-        USAGE INSTRUCTIONS:
-        1. Provide the name of your application
-        2. Optionally describe the symptoms you're experiencing
-        3. The tool will recommend a diagnostic path based on detected issues
-
-        The guidance includes:
-        - Initial assessment of the deployment state
-        - Categorized symptoms detection (infrastructure, service, task, application, network)
-        - Recommended diagnostic tools to use next with reasoning
-        - Raw data about the current deployment state for further analysis
-
-        Parameters:
-            app_name: The name of the application/stack to troubleshoot
-            symptoms_description: Optional description of symptoms experienced by the user
-
-        Returns:
-            Diagnostic path recommendation, initial assessment, and detected symptoms
-        """
-        return get_ecs_troubleshooting_guidance(app_name, symptoms_description)
-
-
-    @mcp.tool(name="fetch_cloudformation_status")
-    async def mcp_fetch_cloudformation_status(
-        stack_id: str = Field(
-            ...,
-            description="The CloudFormation stack identifier to analyze",
-        ),
-    ) -> Dict[str, Any]:
-        """
-        Infrastructure-level diagnostics for CloudFormation stacks.
-
-        This tool analyzes the CloudFormation stack used to deploy your ECS infrastructure.
-        It checks the stack status, identifies failed resources, and extracts error messages
-        to help diagnose infrastructure-level issues.
-        
-        IMPORTANT USAGE GUIDELINES:
-        When this tool reveals specific error messages that explain the deployment failure
-        (such as "Network Configuration must be provided when networkMode 'awsvpc' is specified"),
-        consider this a definitive root cause. Do not use additional tools to verify what is 
-        already clearly indicated by CloudFormation errors.
-
-        USAGE INSTRUCTIONS:
-        1. Provide the name of your application
-        2. The tool will analyze the CloudFormation stack and return detailed information
-
-        The analysis includes:
-        - Stack existence confirmation
-        - Current stack status (e.g., CREATE_COMPLETE, ROLLBACK_COMPLETE)
-        - List of resources with their status
-        - Failed resources with detailed failure reasons
-        - Historical stack events for deeper analysis
-
-        Parameters:
-            stack_id: The CloudFormation stack identifier to analyze
-
-        Returns:
-            Stack status, resources, failure reasons, and raw events
-        """
-        return fetch_cloudformation_status(stack_id)
-
-
-    @mcp.tool(name="fetch_service_events")
-    async def mcp_fetch_service_events(
-        app_name: str = Field(
-            ...,
-            description="The name of the application to analyze",
-        ),
-        cluster_name: str = Field(
-            ...,
-            description="The name of the ECS cluster",
-        ),
-        service_name: str = Field(
-            ...,
-            description="The name of the ECS service to analyze",
-        ),
-        time_window: int = Field(
-            default=3600,
-            description="Time window in seconds to look back for events (default: 3600)",
-        ),
-        start_time: Optional[datetime.datetime] = Field(
-            default=None,
-            description="Explicit start time for the analysis window (UTC, takes precedence over time_window if provided)",
-        ),
-        end_time: Optional[datetime.datetime] = Field(
-            default=None,
-            description="Explicit end time for the analysis window (UTC, defaults to current time if not provided)",
-        ),
-    ) -> Dict[str, Any]:
-        """
-        Service-level diagnostics for ECS services.
-
-        This tool analyzes ECS service events and configuration to identify service-level
-        issues that may be affecting your deployment. It examines recent service events,
-        deployment status, and load balancer configuration.
-
-        USAGE INSTRUCTIONS:
-        1. Provide the name of your application
-        2. Specify the cluster name
-        3. Specify the service name
-        4. Optionally specify the time window to analyze (default is last hour)
-        5. The tool will analyze service events and configuration
-
-        The analysis includes:
-        - Service status summary
-        - Chronological list of service events
-        - Deployment status and history
-        - Load balancer configuration issues
-        - Detailed service configuration
-
-        Parameters:
-            app_name: The name of the application/service to analyze
-            cluster_name: The name of the ECS cluster (optional)
-            time_window: Time window in seconds to look back for events
-
-        Returns:
-            Service status, events, deployment status, and configuration issues
-        """
-        return fetch_service_events(app_name, cluster_name, service_name, time_window, start_time, end_time)
-
-
-    @mcp.tool(name="fetch_task_failures")
-    async def mcp_fetch_task_failures(
-        app_name: str = Field(
-            ...,
-            description="The name of the application to analyze",
-        ),
-        cluster_name: str = Field(
-            ...,
-            description="The name of the ECS cluster",
-        ),
-        time_window: int = Field(
-            default=3600,
-            description="Time window in seconds to look back for failures (default: 3600)",
-        ),
-        start_time: Optional[datetime.datetime] = Field(
-            default=None,
-            description="Explicit start time for the analysis window (UTC, takes precedence over time_window if provided)",
-        ),
-        end_time: Optional[datetime.datetime] = Field(
-            default=None,
-            description="Explicit end time for the analysis window (UTC, defaults to current time if not provided)",
-        ),
-    ) -> Dict[str, Any]:
-        """
-        Task-level diagnostics for ECS task failures.
-
-        This tool analyzes failed ECS tasks to identify patterns and common failure reasons.
-        It categorizes failures by type and extracts relevant information to help diagnose
-        container-level issues.
-
-        USAGE INSTRUCTIONS:
-        1. Provide the name of your application
-        2. Specify the cluster name
-        3. Optionally specify the time window to analyze (default is last hour)
-        4. The tool will analyze failed tasks and identify patterns
-
-        The analysis includes:
-        - List of failed tasks with timestamps
-        - Exit codes and failure reasons
-        - Container status information
-        - Resource utilization at failure time
-        - Categorized failures (image pull, resource constraints, application errors)
-
-        Parameters:
-            app_name: The name of the application to analyze
-            cluster_name: The name of the ECS cluster (optional)
-            time_window: Time window in seconds to look back for failures
-
-        Returns:
-            Failed tasks with timestamps, exit codes, status, and resource utilization
-        """
-        return fetch_task_failures(app_name, cluster_name, time_window, start_time, end_time)
-
-
-    @mcp.tool(name="fetch_task_logs")
-    async def mcp_fetch_task_logs(
-        app_name: str = Field(
-            ...,
-            description="The name of the application to analyze",
-        ),
-        cluster_name: str = Field(
-            ...,
-            description="The name of the ECS cluster",
-        ),
-        task_id: Optional[str] = Field(
-            default=None,
-            description="Specific task ID to retrieve logs for",
-        ),
-        time_window: int = Field(
-            default=3600,
-            description="Time window in seconds to look back for logs (default: 3600)",
-        ),
-        filter_pattern: Optional[str] = Field(
-            default=None,
-            description="CloudWatch logs filter pattern",
-        ),
-        start_time: Optional[datetime.datetime] = Field(
-            default=None,
-            description="Explicit start time for the analysis window (UTC, takes precedence over time_window if provided)",
-        ),
-        end_time: Optional[datetime.datetime] = Field(
-            default=None,
-            description="Explicit end time for the analysis window (UTC, defaults to current time if not provided)",
-        ),
-    ) -> Dict[str, Any]:
-        """
-        Application-level diagnostics through CloudWatch logs.
-
-        This tool retrieves and analyzes CloudWatch logs for your ECS tasks to identify
-        application-level issues. It categorizes log entries by severity, highlights errors,
-        and identifies common error patterns.
-
-        USAGE INSTRUCTIONS:
-        1. Provide the name of your application
-        2. Specify the cluster name
-        3. Optionally provide a specific task ID to focus on a single task
-        4. Optionally specify the time window and filter pattern
-        5. The tool will retrieve and analyze logs
-
-        The analysis includes:
-        - Chronological log entries with severity markers
-        - Highlighted error messages
-        - Context around errors (preceding and following logs)
-        - Log pattern summary (recurring errors)
-        - Error and warning counts
-
-        Parameters:
-            app_name: The name of the application to analyze
-            cluster_name: The name of the ECS cluster (optional)
-            task_id: Specific task ID to retrieve logs for (optional)
-            time_window: Time window in seconds to look back for logs
-            filter_pattern: CloudWatch logs filter pattern (optional)
-
-        Returns:
-            Log entries with severity markers, highlighted errors, context
-        """
-        return fetch_task_logs(app_name, cluster_name, task_id, time_window, filter_pattern, start_time, end_time)
-        
-    @mcp.tool(name="detect_image_pull_failures")
-    async def mcp_detect_image_pull_failures(
-        app_name: str = Field(
-            ...,
-            description="Application name to check for image pull failures",
-        ),
-    ) -> Dict[str, Any]:
-        """
-        Specialized tool for detecting container image pull failures.
-
-        This tool finds all task definitions related to the application and checks
-        if their container images exist and are accessible. It is particularly useful
-        for diagnosing "ImagePullBackOff" type issues in ECS.
-        
-        IMPORTANT USAGE GUIDELINES:
-        This tool provides definitive information about container image issues. 
-        When it confirms an invalid image reference, DO NOT use additional tools
-        to verify what's already known. Proceed directly to recommending solutions
-        based on the findings from this tool.
-
-        USAGE INSTRUCTIONS:
-        1. Provide the name of your application
-        2. The tool will check for image pull failures and provide recommendations
-
-        The analysis includes:
-        - Finding related task definitions by name pattern
-        - Checking ECR repositories for image existence
-        - Validating image references
-        - Providing specific recommendations to fix image issues
-
-        Parameters:
-            app_name: The name of the application to check
-
-        Returns:
-            Dictionary with image issues analysis and recommendations
-        """
-        return detect_image_pull_failures(app_name)
-
-    # Troubleshooting prompt patterns
-    @mcp.prompt("troubleshoot ecs")
-    def troubleshoot_ecs_prompt():
-        """
-        User wants to troubleshoot ECS deployment.
-        Start with get_ecs_troubleshooting_guidance and only use additional
-        tools if the root cause isn't clearly identified in the initial assessment.
-        """
-        return ["get_ecs_troubleshooting_guidance"]
-
-    @mcp.prompt("ecs deployment failed")
-    def ecs_deployment_failed_prompt():
-        """
-        User has an ECS deployment failure.
-        Begin with get_ecs_troubleshooting_guidance and avoid redundant tool usage
-        if a definitive root cause (like image issues or CloudFormation errors) is found.
-        """
-        return ["get_ecs_troubleshooting_guidance"]
-
-    @mcp.prompt("diagnose ecs")
-    def diagnose_ecs_prompt():
-        """
-        User wants to diagnose ECS issues.
-        Use get_ecs_troubleshooting_guidance to identify potential issues and
-        only proceed with additional tools if the root cause isn't clear.
-        """
-        return ["get_ecs_troubleshooting_guidance"]
-
-    @mcp.prompt("ecs tasks failing")
-    def ecs_tasks_failing_prompt():
-        """User has failing ECS tasks"""
-        return ["fetch_task_failures"]
-
-    @mcp.prompt("check ecs logs")
-    def check_ecs_logs_prompt():
-        """User wants to check ECS logs"""
-        return ["fetch_task_logs"]
-
-    @mcp.prompt("cloudformation stack failed")
-    def cloudformation_stack_failed_prompt():
-        """User has a failed CloudFormation stack"""
-        return ["fetch_cloudformation_status"]
-
-    @mcp.prompt("ecs service events")
-    def ecs_service_events_prompt():
-        """User wants to see ECS service events"""
-        return ["fetch_service_events"]
-
-    @mcp.prompt("fix ecs deployment")
-    def fix_ecs_deployment_prompt():
-        """User wants to fix an ECS deployment"""
-        return ["get_ecs_troubleshooting_guidance"]
-
-    # Specific Stack Name Troubleshooting Patterns
-    @mcp.prompt("stack .* is broken")
-    def stack_is_broken_prompt():
-        """User has a broken CloudFormation stack with a specific name"""
-        return ["fetch_cloudformation_status", "get_ecs_troubleshooting_guidance"]
-
-    @mcp.prompt("fix .* stack")
-    def fix_named_stack_prompt():
-        """User wants to fix a specific stack"""
-        return ["fetch_cloudformation_status", "get_ecs_troubleshooting_guidance"]
-
-    @mcp.prompt("failed stack .*")
-    def failed_stack_named_prompt():
-        """User has a failed stack with a specific name"""
-        return ["fetch_cloudformation_status", "get_ecs_troubleshooting_guidance"]
-
-    @mcp.prompt("stack .* failed")
-    def stack_named_failed_prompt():
-        """User has a failed stack with a specific name"""
-        return ["fetch_cloudformation_status", "get_ecs_troubleshooting_guidance"]
-
-    @mcp.prompt(".*-stack.* is broken")
-    def test_stack_is_broken_prompt():
-        """User has a broken test stack with random suffix"""
-        return ["fetch_cloudformation_status", "get_ecs_troubleshooting_guidance"]
-
-    @mcp.prompt(".*-stack.* failed")
-    def test_stack_failed_prompt():
-        """User has a failed test stack with random suffix"""
-        return ["fetch_cloudformation_status", "get_ecs_troubleshooting_guidance"]
-
-    @mcp.prompt("help me fix .*-stack.*")
-    def help_fix_test_stack_prompt():
-        """User wants help fixing a test stack with random suffix"""
-        return ["fetch_cloudformation_status", "get_ecs_troubleshooting_guidance"]
-
-    @mcp.prompt("why did my stack fail")
-    def why_did_stack_fail_prompt():
-        """User wants to know why their stack failed"""
-        return ["fetch_cloudformation_status", "get_ecs_troubleshooting_guidance"]
-
-    # Generic troubleshooting patterns
-    @mcp.prompt("fix my deployment")
-    def fix_deployment_prompt():
-        """User wants to fix their deployment"""
-        return ["get_ecs_troubleshooting_guidance"]
-
-    @mcp.prompt("deployment issues")
-    def deployment_issues_prompt():
-        """User has deployment issues"""
-        return ["get_ecs_troubleshooting_guidance"]
-
-    @mcp.prompt("what's wrong with my stack")
-    def whats_wrong_with_stack_prompt():
-        """User wants to know what's wrong with their stack"""
-        return ["fetch_cloudformation_status", "get_ecs_troubleshooting_guidance"]
-
-    @mcp.prompt("deployment is broken")
-    def deployment_broken_prompt():
-        """User's deployment is broken"""
-        return ["get_ecs_troubleshooting_guidance"]
-
-    @mcp.prompt("app won't deploy")
-    def app_wont_deploy_prompt():
-        """User's app won't deploy"""
-        return ["get_ecs_troubleshooting_guidance"]
-
-    @mcp.prompt("help debug ecs")
-    def help_debug_ecs_prompt():
-        """User wants help debugging ECS"""
-        return ["get_ecs_troubleshooting_guidance"]
-
-    @mcp.prompt("service is failing")
-    def service_failing_prompt():
-        """User's service is failing"""
-        return ["fetch_service_events", "get_ecs_troubleshooting_guidance"]
-
-    @mcp.prompt("container is failing")
-    def container_failing_prompt():
-        """User's container is failing"""
-        return ["fetch_task_failures", "fetch_task_logs", "get_ecs_troubleshooting_guidance"]
+    # Define prompt groups for bulk registration
+    prompt_groups = {
+        "General ECS troubleshooting": [
+            "troubleshoot ecs",
+            "ecs deployment failed", 
+            "diagnose ecs",
+            "fix ecs deployment",
+            "help debug ecs"
+        ],
+        "Task and container issues": [
+            "ecs tasks failing",
+            "container is failing",
+            "service is failing"
+        ],
+        "Infrastructure issues": [
+            "cloudformation stack failed",
+            "stack .* is broken",
+            "fix .* stack",
+            "failed stack .*",
+            "stack .* failed",
+            ".*-stack.* is broken",
+            ".*-stack.* failed",
+            "help me fix .*-stack.*",
+            "why did my stack fail"
+        ],
+        "Image pull failures": [
+            "image pull failure",
+            "container image not found",
+            "imagepullbackoff",
+            "can't pull image",
+            "invalid container image"
+        ],
+        "Network and connectivity": [
+            "network issues",
+            "security group issues", 
+            "connectivity issues",
+            "unable to connect",
+            "service unreachable"
+        ],
+        "Load balancer issues": [
+            "alb not working",
+            "load balancer not working",
+            "alb url not working",
+            "healthcheck failing",
+            "target group",
+            "404 not found"
+        ],
+        "Logs and monitoring": [
+            "check ecs logs",
+            "ecs service events"
+        ],
+        "Generic deployment issues": [
+            "fix my deployment",
+            "deployment issues",
+            "what's wrong with my stack",
+            "deployment is broken",
+            "app won't deploy"
+        ]
+    }
     
-    # New prompts for image pull failures
-    @mcp.prompt("image pull failure")
-    def image_pull_failure_prompt():
-        """
-        User has an image pull failure.
-        Use detect_image_pull_failures for definitive diagnosis. The results from
-        this tool are typically conclusive for image issues, so avoid redundant tool usage.
-        """
-        return ["detect_image_pull_failures"]
-
-    @mcp.prompt("container image not found")
-    def container_image_not_found_prompt():
-        """
-        User has a container image not found error.
-        detect_image_pull_failures will provide a definitive diagnosis and specific
-        recommendations. No need for additional tools once the image issue is confirmed.
-        """
-        return ["detect_image_pull_failures"]
-
-    @mcp.prompt("imagepullbackoff")
-    def imagepullbackoff_prompt():
-        """
-        User has an ImagePullBackOff error.
-        detect_image_pull_failures is sufficient to diagnose this issue.
-        Additional tools are only needed if image validation is inconclusive.
-        """
-        return ["detect_image_pull_failures"]
-        
-    @mcp.prompt("can't pull image")
-    def cant_pull_image_prompt():
-        """
-        User reports that the container can't pull an image.
-        Start with detect_image_pull_failures for direct image validation,
-        then only use get_ecs_troubleshooting_guidance if additional context is needed.
-        Avoid unnecessary tool usage if the image pull failure cause is clear.
-        """
-        return ["detect_image_pull_failures", "get_ecs_troubleshooting_guidance"]
-        
-    @mcp.prompt("invalid container image")
-    def invalid_container_image_prompt():
-        """
-        User has an invalid container image reference.
-        detect_image_pull_failures provides a conclusive diagnosis and specific
-        recommendations for this issue. Additional tool usage is typically unnecessary.
-        """
-        return ["detect_image_pull_failures"]
+    # Register all prompts with bulk registration
+    register_troubleshooting_prompts(mcp, prompt_groups)

--- a/src/ecs-mcp-server/awslabs/ecs_mcp_server/utils/time_utils.py
+++ b/src/ecs-mcp-server/awslabs/ecs_mcp_server/utils/time_utils.py
@@ -1,0 +1,51 @@
+"""
+Utility functions for handling time calculations.
+"""
+
+import datetime
+from typing import Tuple, Optional
+
+
+def calculate_time_window(
+    time_window: int = 3600,
+    start_time: Optional[datetime.datetime] = None,
+    end_time: Optional[datetime.datetime] = None
+) -> Tuple[datetime.datetime, datetime.datetime]:
+    """
+    Calculate the actual start time and end time for a time window.
+    
+    Parameters
+    ----------
+    time_window : int, optional
+        Time window in seconds (default: 3600)
+    start_time : datetime, optional
+        Explicit start time (takes precedence over time_window if provided)
+    end_time : datetime, optional
+        Explicit end time (defaults to current time if not provided)
+    
+    Returns
+    -------
+    Tuple[datetime.datetime, datetime.datetime]
+        Tuple of (actual_start_time, actual_end_time) with timezone info
+    """
+    now = datetime.datetime.now(datetime.timezone.utc)
+    
+    # Handle provided start_time and end_time
+    if end_time is None:
+        # If no end_time provided, use current time
+        actual_end_time = now
+    else:
+        # Ensure end_time is timezone-aware
+        actual_end_time = end_time if end_time.tzinfo else end_time.replace(tzinfo=datetime.timezone.utc)
+    
+    if start_time is not None:
+        # If start_time provided, use it directly
+        actual_start_time = start_time if start_time.tzinfo else start_time.replace(tzinfo=datetime.timezone.utc)
+    elif end_time is not None:
+        # If only end_time provided, calculate start_time using time_window
+        actual_start_time = actual_end_time - datetime.timedelta(seconds=time_window)
+    else:
+        # Default case: use time_window from now
+        actual_start_time = now - datetime.timedelta(seconds=time_window)
+    
+    return actual_start_time, actual_end_time

--- a/src/ecs-mcp-server/tests/unit/api/test_ecs_troubleshooting.py
+++ b/src/ecs-mcp-server/tests/unit/api/test_ecs_troubleshooting.py
@@ -1,0 +1,423 @@
+import pytest
+from unittest.mock import Mock, patch
+
+from awslabs.ecs_mcp_server.api.ecs_troubleshooting import (
+    ecs_troubleshooting_tool,
+    _validate_action,
+    _validate_parameters,
+    ACTIONS,
+    generate_troubleshooting_docs,
+    TROUBLESHOOTING_DOCS,
+)
+
+
+class TestEcsTroubleshootingTool:
+
+    def test_valid_action_validation(self):
+        for action in ACTIONS.keys():
+            _validate_action(action)
+
+    def test_invalid_action_validation(self):
+        with pytest.raises(ValueError, match="Invalid action 'invalid_action'"):
+            _validate_action("invalid_action")
+
+    def test_parameter_validation_with_app_name_required(self):
+        with pytest.raises(ValueError, match="app_name is required"):
+            _validate_parameters("get_ecs_troubleshooting_guidance", None, {})
+        
+        _validate_parameters("get_ecs_troubleshooting_guidance", "test-app", {})
+
+    def test_parameter_validation_with_missing_required_params(self):
+        with pytest.raises(ValueError, match="Missing required parameter 'cluster_name'"):
+            _validate_parameters("fetch_service_events", "test-app", {"service_name": "test-service"})
+
+    def test_parameter_validation_success(self):
+        _validate_parameters(
+            "fetch_service_events",
+            "test-app",
+            {"cluster_name": "test-cluster", "service_name": "test-service"}
+        )
+
+    def test_transformer_functions_exist(self):
+        for action, config in ACTIONS.items():
+            assert "transformer" in config, f"Missing transformer for action: {action}"
+            assert callable(config["transformer"]), f"Transformer for {action} is not callable"
+
+    def test_guidance_transformer(self):
+        config = ACTIONS["get_ecs_troubleshooting_guidance"]
+        result = config["transformer"]("test-app", {"symptoms_description": "ALB issues"})
+        expected = {
+            "app_name": "test-app",
+            "symptoms_description": "ALB issues"
+        }
+        assert result == expected
+
+    def test_cloudformation_transformer(self):
+        config = ACTIONS["fetch_cloudformation_status"]
+        
+        result = config["transformer"]("test-app", {"stack_id": "custom-stack"})
+        expected = {"stack_id": "custom-stack"}
+        assert result == expected
+
+        result = config["transformer"]("test-app", {})
+        expected = {"stack_id": "test-app"}
+        assert result == expected
+
+    def test_service_events_transformer(self):
+        config = ACTIONS["fetch_service_events"]
+        result = config["transformer"]("test-app", {
+            "cluster_name": "test-cluster",
+            "service_name": "test-service",
+            "time_window": 7200,
+            "start_time": "2023-01-01T12:00:00Z"
+        })
+        assert result["app_name"] == "test-app"
+        assert result["cluster_name"] == "test-cluster"
+        assert result["service_name"] == "test-service"
+        assert result["time_window"] == 7200
+        assert result["start_time"] == "2023-01-01T12:00:00Z"
+
+    def test_task_failures_transformer(self):
+        config = ACTIONS["fetch_task_failures"]
+        result = config["transformer"]("test-app", {"cluster_name": "test-cluster"})
+        expected = {
+            "app_name": "test-app",
+            "cluster_name": "test-cluster",
+            "time_window": 3600,
+            "start_time": None,
+            "end_time": None
+        }
+        assert result == expected
+
+    def test_image_pull_transformer(self):
+        config = ACTIONS["detect_image_pull_failures"]
+        result = config["transformer"]("test-app", {})
+        expected = {"app_name": "test-app"}
+        assert result == expected
+
+    def test_ecs_troubleshooting_tool_success(self):
+        mock_guidance = Mock(return_value={"status": "success", "guidance": "test guidance"})
+        
+        original_func = ACTIONS["get_ecs_troubleshooting_guidance"]["func"]
+        ACTIONS["get_ecs_troubleshooting_guidance"]["func"] = mock_guidance
+        
+        try:
+            result = ecs_troubleshooting_tool(
+                app_name="test-app",
+                action="get_ecs_troubleshooting_guidance",
+                parameters={"symptoms_description": "ALB issues"}
+            )
+            
+            assert result == {"status": "success", "guidance": "test guidance"}
+            mock_guidance.assert_called_once_with(
+                app_name="test-app",
+                symptoms_description="ALB issues"
+            )
+        finally:
+            ACTIONS["get_ecs_troubleshooting_guidance"]["func"] = original_func
+
+    def test_ecs_troubleshooting_tool_cloudformation(self):
+        mock_cf_status = Mock(return_value={"status": "success", "stack_status": "CREATE_COMPLETE"})
+        
+        original_func = ACTIONS["fetch_cloudformation_status"]["func"]
+        ACTIONS["fetch_cloudformation_status"]["func"] = mock_cf_status
+        
+        try:
+            result = ecs_troubleshooting_tool(
+                app_name="test-app",
+                action="fetch_cloudformation_status",
+                parameters={"stack_id": "test-stack"}
+            )
+            
+            assert result == {"status": "success", "stack_status": "CREATE_COMPLETE"}
+            mock_cf_status.assert_called_once_with(stack_id="test-stack")
+        finally:
+            ACTIONS["fetch_cloudformation_status"]["func"] = original_func
+
+    def test_ecs_troubleshooting_tool_invalid_action(self):
+        result = ecs_troubleshooting_tool(
+            app_name="test-app",
+            action="invalid_action",
+            parameters={}
+        )
+        
+        assert result["status"] == "error"
+        assert "Invalid action" in result["error"]
+
+    def test_ecs_troubleshooting_tool_missing_parameters(self):
+        result = ecs_troubleshooting_tool(
+            app_name=None,
+            action="get_ecs_troubleshooting_guidance",
+            parameters={}
+        )
+        
+        assert result["status"] == "error"
+        assert "app_name is required" in result["error"]
+
+    def test_ecs_troubleshooting_tool_function_exception(self):
+        mock_guidance = Mock(side_effect=Exception("Test exception"))
+        
+        original_func = ACTIONS["get_ecs_troubleshooting_guidance"]["func"]
+        ACTIONS["get_ecs_troubleshooting_guidance"]["func"] = mock_guidance
+        
+        try:
+            result = ecs_troubleshooting_tool(
+                app_name="test-app",
+                action="get_ecs_troubleshooting_guidance",
+                parameters={}
+            )
+            
+            assert result["status"] == "error"
+            assert "Internal error" in result["error"]
+        finally:
+            ACTIONS["get_ecs_troubleshooting_guidance"]["func"] = original_func
+
+    def test_ecs_troubleshooting_tool_none_parameters(self):
+        mock_guidance = Mock(return_value={"status": "success"})
+        
+        original_func = ACTIONS["get_ecs_troubleshooting_guidance"]["func"]
+        ACTIONS["get_ecs_troubleshooting_guidance"]["func"] = mock_guidance
+        
+        try:
+            result = ecs_troubleshooting_tool(
+                app_name="test-app",
+                action="get_ecs_troubleshooting_guidance",
+                parameters=None
+            )
+            
+            assert result == {"status": "success"}
+            mock_guidance.assert_called_once_with(
+                app_name="test-app",
+                symptoms_description=None
+            )
+        finally:
+            ACTIONS["get_ecs_troubleshooting_guidance"]["func"] = original_func
+
+    def test_actions_structure_completeness(self):
+        expected_actions = [
+            "get_ecs_troubleshooting_guidance",
+            "fetch_cloudformation_status",
+            "fetch_service_events",
+            "fetch_task_failures",
+            "fetch_task_logs",
+            "detect_image_pull_failures"
+        ]
+        
+        for action in expected_actions:
+            assert action in ACTIONS, f"Missing action in ACTIONS: {action}"
+            assert "func" in ACTIONS[action], f"Missing func for action: {action}"
+            assert "required_params" in ACTIONS[action], f"Missing required_params for action: {action}"
+            assert "transformer" in ACTIONS[action], f"Missing transformer for action: {action}"
+        
+        assert len(ACTIONS) == len(expected_actions), "ACTIONS has unexpected actions"
+
+    def test_required_params_mapping(self):
+        for action, config in ACTIONS.items():
+            assert "required_params" in config, f"Missing required_params for action: {action}"
+            assert isinstance(config["required_params"], list), f"required_params must be a list for action: {action}"
+
+
+class TestTransformerFunctions:
+
+    def test_service_events_transformer_with_time_parameters(self):
+        config = ACTIONS["fetch_service_events"]
+        result = config["transformer"]("test-app", {
+            "cluster_name": "test-cluster",
+            "service_name": "test-service",
+            "time_window": 1800,
+            "start_time": "2023-01-01T10:00:00Z",
+            "end_time": "2023-01-01T11:00:00Z"
+        })
+        
+        assert result["time_window"] == 1800
+        assert result["start_time"] == "2023-01-01T10:00:00Z"
+        assert result["end_time"] == "2023-01-01T11:00:00Z"
+
+    def test_task_logs_transformer_with_all_parameters(self):
+        config = ACTIONS["fetch_task_logs"]
+        result = config["transformer"]("test-app", {
+            "cluster_name": "test-cluster",
+            "task_id": "task-abc123",
+            "time_window": 1200,
+            "filter_pattern": "[timestamp, request_id, level=\"ERROR\"]",
+            "start_time": "2023-01-01T10:00:00Z"
+        })
+        
+        assert result["task_id"] == "task-abc123"
+        assert result["time_window"] == 1200
+        assert result["filter_pattern"] == "[timestamp, request_id, level=\"ERROR\"]"
+        assert result["start_time"] == "2023-01-01T10:00:00Z"
+        assert result["end_time"] is None
+
+
+
+class TestEdgeCases:
+
+    def test_empty_app_name(self):
+        with pytest.raises(ValueError, match="app_name is required"):
+            _validate_parameters("get_ecs_troubleshooting_guidance", "", {})
+
+    def test_whitespace_app_name(self):
+        with pytest.raises(ValueError, match="app_name is required"):
+            _validate_parameters("get_ecs_troubleshooting_guidance", "   ", {})
+
+    def test_case_sensitive_action(self):
+        with pytest.raises(ValueError, match="Invalid action"):
+            _validate_action("GET_ECS_TROUBLESHOOTING_GUIDANCE")
+
+    def test_transformer_extra_parameters_ignored(self):
+        config = ACTIONS["detect_image_pull_failures"]
+        result = config["transformer"]("test-app", {
+            "extra_param": "ignored",
+            "another_extra": 123
+        })
+        
+        assert result == {"app_name": "test-app"}
+        assert "extra_param" not in result
+        assert "another_extra" not in result
+
+
+class TestGenerateTroubleshootingDocs:
+    """Test cases for the generate_troubleshooting_docs function."""
+
+    def test_docs_not_empty(self):
+        """Test that generated docs are not empty."""
+        docs = generate_troubleshooting_docs()
+        assert docs
+        assert isinstance(docs, str)
+        assert len(docs) > 100  # Reasonable assumption that docs should be substantial
+
+    def test_docs_contains_all_actions(self):
+        """Test that the documentation contains information about all actions."""
+        docs = generate_troubleshooting_docs()
+        for action_name in ACTIONS.keys():
+            assert action_name in docs, f"Documentation should mention action: {action_name}"
+
+    def test_docs_contains_examples(self):
+        """Test that the documentation contains examples for each action."""
+        docs = generate_troubleshooting_docs()
+        assert "Example:" in docs, "Documentation should contain examples"
+        
+        # Check for quick usage examples section
+        assert "Quick Usage Examples" in docs, "Documentation should have a Quick Usage Examples section"
+
+    def test_docs_formatting(self):
+        """Test that the documentation has correct formatting."""
+        docs = generate_troubleshooting_docs()
+        assert "## Available Actions and Parameters:" in docs, "Missing section header for actions"
+        assert "Parameters:" in docs, "Missing parameters section"
+        assert "Returns:" in docs, "Missing returns section"
+
+    def test_docs_with_mocked_action(self):
+        """Test documentation generation with a mocked action."""
+        # Create a copy of ACTIONS to avoid modifying the global dictionary
+        test_actions = dict(ACTIONS)
+        test_actions["test_action"] = {
+            "func": lambda x: x,
+            "required_params": ["param1"],
+            "optional_params": ["param2"],
+            "transformer": lambda app_name, params: params,
+            "description": "Test action description",
+            "param_descriptions": {"param1": "First param", "param2": "Second param"},
+            "example": 'action="test_action", parameters={"param1": "value1"}'
+        }
+        
+        # Use patch context manager to temporarily replace ACTIONS
+        with patch('awslabs.ecs_mcp_server.api.ecs_troubleshooting.ACTIONS', test_actions):
+            # Now generate docs with our modified ACTIONS dictionary
+            docs = generate_troubleshooting_docs()
+            
+            # Basic checks for added action
+            assert "test_action" in docs, "Added action should appear in docs"
+            assert "Test action description" in docs, "Action description should be included"
+            
+            # Check that our action appears in the quick usage examples
+            assert 'action: "test_action"' in docs
+            assert 'parameters: {"param1": "value1"}' in docs
+            
+            # Make sure the required parameters are listed
+            assert "- Required: param1" in docs
+            # Check for optional parameters section with param2
+            assert "- Optional: param2" in docs
+
+    def test_troubleshooting_docs_constant(self):
+        """Test that the TROUBLESHOOTING_DOCS constant is set."""
+        assert TROUBLESHOOTING_DOCS
+        assert isinstance(TROUBLESHOOTING_DOCS, str)
+        assert TROUBLESHOOTING_DOCS == generate_troubleshooting_docs()
+
+
+class TestGuardrails:
+    """Guardrail tests that will fail if actions change without updating the tests."""
+
+    def test_actions_count_unchanged(self):
+        """Fail if new actions are added/removed without updating this test."""
+        assert len(ACTIONS) == 6, f"Expected 6 actions, got {len(ACTIONS)}. Update test if this is intentional."
+
+    def test_expected_actions_exist(self):
+        """Fail if action names change or new ones are added."""
+        expected_actions = {
+            "get_ecs_troubleshooting_guidance",
+            "fetch_cloudformation_status", 
+            "fetch_service_events",
+            "fetch_task_failures",
+            "fetch_task_logs", 
+            "detect_image_pull_failures"
+        }
+        actual_actions = set(ACTIONS.keys())
+        assert actual_actions == expected_actions, f"Actions changed! Expected: {expected_actions}, Got: {actual_actions}"
+
+    def test_parameter_counts_unchanged(self):
+        """Fail if parameter counts change without updating test."""
+        expected_param_counts = {
+            "get_ecs_troubleshooting_guidance": {"required": 1, "optional": 1},
+            "fetch_cloudformation_status": {"required": 1, "optional": 0},
+            "fetch_service_events": {"required": 3, "optional": 3},
+            "fetch_task_failures": {"required": 2, "optional": 3},
+            "fetch_task_logs": {"required": 2, "optional": 5},
+            "detect_image_pull_failures": {"required": 1, "optional": 0}
+        }
+        
+        for action_name, expected_counts in expected_param_counts.items():
+            config = ACTIONS[action_name]
+            required_count = len(config["required_params"])
+            optional_count = len(config.get("optional_params", []))
+            
+            assert required_count == expected_counts["required"], \
+                f"{action_name}: Expected {expected_counts['required']} required params, got {required_count}"
+            assert optional_count == expected_counts["optional"], \
+                f"{action_name}: Expected {expected_counts['optional']} optional params, got {optional_count}"
+
+    def test_documentation_contains_expected_content(self):
+        """Fail if generated docs are missing expected action descriptions."""
+        docs = generate_troubleshooting_docs()
+        expected_in_docs = [
+            "get_ecs_troubleshooting_guidance",
+            "fetch_cloudformation_status",
+            "Initial assessment and data collection",
+            "Infrastructure-level diagnostics",
+            "Service-level diagnostics", 
+            "Task-level diagnostics",
+            "Application-level diagnostics",
+            "Specialized tool for detecting container image"
+        ]
+        
+        for expected in expected_in_docs:
+            assert expected in docs, f"Documentation missing expected content: '{expected}'"
+
+    def test_actions_have_required_fields(self):
+        """Fail if any action is missing required configuration fields."""
+        required_fields = ["func", "required_params", "optional_params", "transformer", "description", "param_descriptions", "example"]
+        
+        for action_name, config in ACTIONS.items():
+            for field in required_fields:
+                assert field in config, f"Action '{action_name}' missing required field: '{field}'"
+                
+            # Verify field types
+            assert callable(config["func"]), f"Action '{action_name}' func must be callable"
+            assert callable(config["transformer"]), f"Action '{action_name}' transformer must be callable"
+            assert isinstance(config["required_params"], list), f"Action '{action_name}' required_params must be list"
+            assert isinstance(config["optional_params"], list), f"Action '{action_name}' optional_params must be list"
+            assert isinstance(config["description"], str), f"Action '{action_name}' description must be string"
+            assert isinstance(config["param_descriptions"], dict), f"Action '{action_name}' param_descriptions must be dict"
+            assert isinstance(config["example"], str), f"Action '{action_name}' example must be string"

--- a/src/ecs-mcp-server/tests/unit/test_image_pull_failure.py
+++ b/src/ecs-mcp-server/tests/unit/test_image_pull_failure.py
@@ -17,9 +17,9 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from awslabs.ecs_mcp_server.api.troubleshooting_tools.detect_image_pull_failures import detect_image_pull_failures
 from awslabs.ecs_mcp_server.api.troubleshooting_tools.get_ecs_troubleshooting_guidance import (
-    find_related_resources,
-    find_related_task_definitions,
-    check_container_images,
+    discover_resources,
+    get_task_definitions,
+    validate_container_images,
 )
 
 
@@ -27,8 +27,8 @@ class TestImagePullFailureDetection(unittest.TestCase):
     """Test the image pull failure detection functionality."""
 
     @patch('awslabs.ecs_mcp_server.api.troubleshooting_tools.get_ecs_troubleshooting_guidance.boto3.client')
-    def test_find_related_resources(self, mock_boto3_client):
-        """Test finding related resources."""
+    def test_discover_resources(self, mock_boto3_client):
+        """Test discovering related resources."""
         # Mock the ECS client
         mock_ecs = MagicMock()
         mock_ecs.list_clusters.return_value = {
@@ -37,12 +37,24 @@ class TestImagePullFailureDetection(unittest.TestCase):
                 'arn:aws:ecs:us-west-2:123456789012:cluster/another-cluster'
             ]
         }
-        mock_ecs.list_task_definitions.return_value = {
-            'taskDefinitionArns': [
-                'arn:aws:ecs:us-west-2:123456789012:task-definition/test-failure-task-def-prbqv:1',
-                'arn:aws:ecs:us-west-2:123456789012:task-definition/other-task:1'
-            ]
-        }
+        
+        # Mock the paginator for list_task_definitions
+        mock_task_paginator = MagicMock()
+        mock_task_paginator.paginate.return_value = [
+            {
+                'taskDefinitionArns': [
+                    'arn:aws:ecs:us-west-2:123456789012:task-definition/test-failure-task-def-prbqv:1',
+                    'arn:aws:ecs:us-west-2:123456789012:task-definition/other-task:1'
+                ]
+            }
+        ]
+
+        def get_paginator_side_effect(operation_name):
+            if operation_name == 'list_task_definitions':
+                return mock_task_paginator
+            return MagicMock()
+            
+        mock_ecs.get_paginator.side_effect = get_paginator_side_effect
         
         # Mock describe_task_definition for the task definitions
         mock_ecs.describe_task_definition.return_value = {
@@ -51,11 +63,6 @@ class TestImagePullFailureDetection(unittest.TestCase):
                 'family': 'test-failure-task-def-prbqv',
                 'revision': 1
             }
-        }
-        
-        # Mock list_task_definition_families
-        mock_ecs.list_task_definition_families.return_value = {
-            'families': ['test-failure-task-def-prbqv']
         }
         
         # Mock the ELBv2 client
@@ -77,8 +84,7 @@ class TestImagePullFailureDetection(unittest.TestCase):
         
         mock_boto3_client.side_effect = mock_client
         
-        # Call the function
-        result = find_related_resources('test-failure')
+        result, _ = discover_resources('test-failure')
         
         # Verify the result
         self.assertIn('test-failure-cluster-prbqv', result['clusters'])
@@ -86,26 +92,25 @@ class TestImagePullFailureDetection(unittest.TestCase):
         self.assertIn('test-failure-lb-prbqv', result['load_balancers'])
         
     @patch('awslabs.ecs_mcp_server.api.troubleshooting_tools.get_ecs_troubleshooting_guidance.boto3.client')
-    def test_find_related_task_definitions(self, mock_boto3_client):
-        """Test finding related task definitions."""
+    def test_get_task_definitions(self, mock_boto3_client):
+        """Test getting related task definitions."""
         # Mock the ECS client
         mock_ecs = MagicMock()
         
-        # Mock list_task_definition_families
-        mock_ecs.list_task_definition_families.return_value = {
-            'families': ['failing-task-def-prbqv']
-        }
-        
-        # Mock list_task_definitions
-        mock_ecs.list_task_definitions.return_value = {
-            'taskDefinitionArns': ['arn:aws:ecs:us-west-2:123456789012:task-definition/failing-task-def-prbqv:1']
-        }
+        # Mock paginator for list_task_definitions
+        mock_paginator = MagicMock()
+        mock_paginator.paginate.return_value = [{
+            'taskDefinitionArns': [
+                'arn:aws:ecs:us-west-2:123456789012:task-definition/test-failure-prbqv:1'
+            ]
+        }]
+        mock_ecs.get_paginator.return_value = mock_paginator
         
         # Mock describe_task_definition
         mock_ecs.describe_task_definition.return_value = {
             'taskDefinition': {
-                'taskDefinitionArn': 'arn:aws:ecs:us-west-2:123456789012:task-definition/failing-task-def-prbqv:1',
-                'family': 'failing-task-def-prbqv',
+                'taskDefinitionArn': 'arn:aws:ecs:us-west-2:123456789012:task-definition/test-failure-prbqv:1',
+                'family': 'test-failure-prbqv',
                 'revision': 1,
                 'containerDefinitions': [
                     {
@@ -120,17 +125,16 @@ class TestImagePullFailureDetection(unittest.TestCase):
         mock_boto3_client.return_value = mock_ecs
         
         # Call the function
-        result = find_related_task_definitions('test-failure-prbqv')
-        
-        # The function returns 8 variations of related task definitions
-        self.assertEqual(len(result), 8)
-        self.assertEqual(result[0]['family'], 'failing-task-def-prbqv')
+        result = get_task_definitions('test-failure-prbqv')
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]['family'], 'test-failure-prbqv')
         self.assertEqual(result[0]['containerDefinitions'][0]['image'], 
                          'non-existent-repo/non-existent-image:latest')
         
     @patch('awslabs.ecs_mcp_server.api.troubleshooting_tools.get_ecs_troubleshooting_guidance.boto3.client')
-    def test_check_container_images(self, mock_boto3_client):
-        """Test checking container images."""
+    def test_validate_container_images(self, mock_boto3_client):
+        """Test validating container images."""
         # Mock the ECR client
         mock_ecr = MagicMock()
         
@@ -163,7 +167,7 @@ class TestImagePullFailureDetection(unittest.TestCase):
         ]
         
         # Call the function
-        result = check_container_images(task_defs)
+        result = validate_container_images(task_defs)
         
         # Verify the result
         self.assertEqual(len(result), 1)
@@ -171,9 +175,9 @@ class TestImagePullFailureDetection(unittest.TestCase):
         self.assertEqual(result[0]['exists'], 'unknown')  # External images have unknown status
         self.assertEqual(result[0]['repository_type'], 'external')
         
-    @patch('awslabs.ecs_mcp_server.api.troubleshooting_tools.detect_image_pull_failures.find_related_task_definitions')
-    @patch('awslabs.ecs_mcp_server.api.troubleshooting_tools.detect_image_pull_failures.check_container_images')
-    def test_detect_image_pull_failures(self, mock_check_images, mock_find_task_defs):
+    @patch('awslabs.ecs_mcp_server.api.troubleshooting_tools.detect_image_pull_failures.get_task_definitions')
+    @patch('awslabs.ecs_mcp_server.api.troubleshooting_tools.detect_image_pull_failures.validate_container_images')
+    def test_detect_image_pull_failures(self, mock_validate_images, mock_find_task_defs):
         """Test the detect_image_pull_failures function."""
         # Mock the task definitions
         mock_find_task_defs.return_value = [
@@ -190,7 +194,7 @@ class TestImagePullFailureDetection(unittest.TestCase):
         ]
         
         # Mock the image check results
-        mock_check_images.return_value = [
+        mock_validate_images.return_value = [
             {
                 'image': 'non-existent-repo/non-existent-image:latest',
                 'task_definition': 'arn:aws:ecs:us-west-2:123456789012:task-definition/failing-task-def-prbqv:1',

--- a/src/ecs-mcp-server/tests/unit/test_main.py
+++ b/src/ecs-mcp-server/tests/unit/test_main.py
@@ -24,9 +24,9 @@ class MockFastMCP:
         self.tools = []
         self.prompt_patterns = []
     
-    def tool(self, name=None, annotations=None):
+    def tool(self, name=None, description=None, annotations=None):
         def decorator(func):
-            self.tools.append({"name": name or func.__name__, "function": func, "annotations": annotations})
+            self.tools.append({"name": name or func.__name__, "function": func, "annotations": annotations, "description": description})
             return func
         return decorator
     

--- a/src/ecs-mcp-server/tests/unit/test_status.py
+++ b/src/ecs-mcp-server/tests/unit/test_status.py
@@ -1,0 +1,548 @@
+"""
+Unit tests for the status.py module that handles deployment status checks.
+"""
+
+import datetime
+import unittest
+from unittest import mock
+
+import pytest
+from botocore.exceptions import ClientError
+
+from awslabs.ecs_mcp_server.api import status
+
+
+class TestDeploymentStatus(unittest.TestCase):
+    """Unit tests for the status.py module."""
+
+    @mock.patch("awslabs.ecs_mcp_server.api.status._find_cloudformation_stack")
+    @mock.patch("awslabs.ecs_mcp_server.api.status._get_alb_url")
+    @mock.patch("awslabs.ecs_mcp_server.api.status.get_aws_client")
+    async def test_get_deployment_status_success(self, mock_get_aws_client, mock_get_alb_url, mock_find_cloudformation_stack):
+        """Test successful deployment status retrieval."""
+        # Setup mock responses
+        mock_find_cloudformation_stack.return_value = ("test-app-ecs-infrastructure", {
+            "status": "CREATE_COMPLETE",
+            "outputs": {},
+            "recent_events": []
+        })
+        mock_get_alb_url.return_value = "http://test-app-123.us-west-2.elb.amazonaws.com"
+        
+        mock_ecs_client = mock.MagicMock()
+        mock_ecs_client.describe_services.return_value = {
+            "services": [
+                {
+                    "serviceName": "test-app-service",
+                    "status": "ACTIVE",
+                    "deployments": [
+                        {
+                            "status": "PRIMARY",
+                            "rolloutState": "COMPLETED",
+                            "runningCount": 2,
+                            "desiredCount": 2,
+                        }
+                    ],
+                    "runningCount": 2,
+                    "desiredCount": 2,
+                    "pendingCount": 0,
+                }
+            ]
+        }
+        mock_ecs_client.list_tasks.return_value = {"taskArns": ["arn:aws:ecs:us-west-2:123456789012:task/test-cluster/abcdef"]}
+        mock_ecs_client.describe_tasks.return_value = {
+            "tasks": [
+                {
+                    "taskArn": "arn:aws:ecs:us-west-2:123456789012:task/test-cluster/abcdef",
+                    "lastStatus": "RUNNING",
+                    "healthStatus": "HEALTHY",
+                    "startedAt": datetime.datetime.now(),
+                }
+            ]
+        }
+        
+        mock_get_aws_client.return_value = mock_ecs_client
+        
+        # Call the function
+        result = await status.get_deployment_status("test-app")
+        
+        # Verify the result
+        assert result["status"] == "COMPLETE"
+        assert result["app_name"] == "test-app"
+        assert result["alb_url"] == "http://test-app-123.us-west-2.elb.amazonaws.com"
+        assert result["service_status"] == "ACTIVE"
+        assert result["deployment_status"] == "COMPLETED"
+        assert result["running_count"] == 2
+        assert result["desired_count"] == 2
+        assert "custom_domain_guidance" in result
+        
+        # Verify the function calls
+        mock_find_cloudformation_stack.assert_called_once_with("test-app", None)
+        mock_get_alb_url.assert_called_once_with("test-app", "test-app-ecs-infrastructure")
+        mock_get_aws_client.assert_called_once_with("ecs")
+
+    @mock.patch("awslabs.ecs_mcp_server.api.status._find_cloudformation_stack")
+    @mock.patch("awslabs.ecs_mcp_server.api.status._get_alb_url")
+    @mock.patch("awslabs.ecs_mcp_server.api.status.get_aws_client")
+    async def test_get_deployment_status_stack_not_found(self, mock_get_aws_client, mock_get_alb_url, mock_find_cloudformation_stack):
+        """Test when CloudFormation stack is not found."""
+        # Setup mock responses
+        mock_find_cloudformation_stack.return_value = (None, {
+            "status": "NOT_FOUND",
+            "details": "No stack found with any naming pattern"
+        })
+        
+        # Call the function
+        result = await status.get_deployment_status("test-app")
+        
+        # Verify the result
+        assert result["status"] == "INFRASTRUCTURE_UNAVAILABLE"
+        assert result["app_name"] == "test-app"
+        assert result["alb_url"] is None
+        
+        # Verify the function calls
+        mock_find_cloudformation_stack.assert_called_once_with("test-app", None)
+        mock_get_alb_url.assert_not_called()
+        mock_get_aws_client.assert_not_called()
+
+    @mock.patch("awslabs.ecs_mcp_server.api.status._find_cloudformation_stack")
+    @mock.patch("awslabs.ecs_mcp_server.api.status._get_alb_url")
+    @mock.patch("awslabs.ecs_mcp_server.api.status.get_aws_client")
+    async def test_get_deployment_status_service_not_found(self, mock_get_aws_client, mock_get_alb_url, mock_find_cloudformation_stack):
+        """Test when ECS service is not found."""
+        # Setup mock responses
+        mock_find_cloudformation_stack.return_value = ("test-app-ecs", {
+            "status": "CREATE_COMPLETE",
+            "outputs": {},
+            "recent_events": []
+        })
+        mock_get_alb_url.return_value = "http://test-app-123.us-west-2.elb.amazonaws.com"
+        
+        mock_ecs_client = mock.MagicMock()
+        mock_ecs_client.describe_services.return_value = {
+            "services": [],
+            "failures": [
+                {
+                    "arn": "arn:aws:ecs:us-west-2:123456789012:service/test-app/test-app-service",
+                    "reason": "MISSING"
+                }
+            ]
+        }
+        mock_get_aws_client.return_value = mock_ecs_client
+        
+        # Call the function
+        result = await status.get_deployment_status("test-app")
+        
+        # Verify the result
+        assert result["status"] == "NOT_FOUND"
+        assert result["app_name"] == "test-app"
+        assert result["alb_url"] is None
+        
+        # Verify the function calls
+        mock_find_cloudformation_stack.assert_called_once_with("test-app", None)
+        mock_get_alb_url.assert_called_once_with("test-app", "test-app-ecs")
+        mock_get_aws_client.assert_called_once_with("ecs")
+
+    @mock.patch("awslabs.ecs_mcp_server.api.status._find_cloudformation_stack")
+    @mock.patch("awslabs.ecs_mcp_server.api.status._get_alb_url")
+    @mock.patch("awslabs.ecs_mcp_server.api.status.get_aws_client")
+    async def test_get_deployment_status_with_custom_params(self, mock_get_aws_client, mock_get_alb_url, mock_find_cloudformation_stack):
+        """Test deployment status retrieval with custom parameters."""
+        # Setup mock responses
+        mock_find_cloudformation_stack.return_value = ("custom-stack", {
+            "status": "CREATE_COMPLETE",
+            "outputs": {},
+            "recent_events": []
+        })
+        mock_get_alb_url.return_value = "http://custom-alb.us-west-2.elb.amazonaws.com"
+        
+        mock_ecs_client = mock.MagicMock()
+        mock_ecs_client.describe_services.return_value = {
+            "services": [
+                {
+                    "serviceName": "custom-service",
+                    "status": "ACTIVE",
+                    "deployments": [
+                        {
+                            "status": "PRIMARY",
+                            "rolloutState": "COMPLETED",
+                            "runningCount": 1,
+                            "desiredCount": 1,
+                        }
+                    ],
+                    "runningCount": 1,
+                    "desiredCount": 1,
+                    "pendingCount": 0,
+                }
+            ]
+        }
+        mock_ecs_client.list_tasks.return_value = {"taskArns": ["arn:aws:ecs:us-west-2:123456789012:task/custom-cluster/abcdef"]}
+        mock_ecs_client.describe_tasks.return_value = {
+            "tasks": [
+                {
+                    "taskArn": "arn:aws:ecs:us-west-2:123456789012:task/custom-cluster/abcdef",
+                    "lastStatus": "RUNNING",
+                    "healthStatus": "HEALTHY",
+                    "startedAt": datetime.datetime.now(),
+                }
+            ]
+        }
+        
+        mock_get_aws_client.return_value = mock_ecs_client
+        
+        # Call the function with custom parameters
+        result = await status.get_deployment_status(
+            "test-app", 
+            cluster_name="custom-cluster", 
+            stack_name="custom-stack", 
+            service_name="custom-service"
+        )
+        
+        # Verify the result
+        assert result["status"] == "COMPLETE"
+        assert result["app_name"] == "test-app"
+        assert result["cluster"] == "custom-cluster"
+        assert result["alb_url"] == "http://custom-alb.us-west-2.elb.amazonaws.com"
+        assert result["service_status"] == "ACTIVE"
+        
+        # Verify the function calls
+        mock_find_cloudformation_stack.assert_called_once_with("test-app", "custom-stack")
+        mock_get_alb_url.assert_called_once_with("test-app", "custom-stack")
+        mock_get_aws_client.assert_called_once_with("ecs")
+        mock_ecs_client.describe_services.assert_called_once_with(cluster="custom-cluster", services=["custom-service"])
+
+    @mock.patch("awslabs.ecs_mcp_server.api.status._find_cloudformation_stack")
+    @mock.patch("awslabs.ecs_mcp_server.api.status._get_alb_url")
+    @mock.patch("awslabs.ecs_mcp_server.api.status.get_aws_client")
+    async def test_get_deployment_status_exception_handling(self, mock_get_aws_client, mock_get_alb_url, mock_find_cloudformation_stack):
+        """Test exception handling in deployment status retrieval."""
+        # Setup mock responses
+        mock_find_cloudformation_stack.return_value = ("test-app-ecs", {
+            "status": "CREATE_COMPLETE",
+            "outputs": {},
+            "recent_events": []
+        })
+        mock_get_alb_url.return_value = "http://test-app-123.us-west-2.elb.amazonaws.com"
+        
+        # Simulate an exception in describe_services
+        mock_ecs_client = mock.MagicMock()
+        mock_ecs_client.describe_services.side_effect = ClientError(
+            {"Error": {"Code": "ClusterNotFoundException", "Message": "Cluster not found"}},
+            "DescribeServices"
+        )
+        mock_get_aws_client.return_value = mock_ecs_client
+        
+        # Call the function
+        result = await status.get_deployment_status("test-app")
+        
+        # Verify the result
+        assert result["status"] == "ERROR"
+        assert result["app_name"] == "test-app"
+        assert result["alb_url"] == "http://test-app-123.us-west-2.elb.amazonaws.com"
+        assert "ClusterNotFoundException" in result["message"]
+        
+        # Verify the function calls
+        mock_find_cloudformation_stack.assert_called_once_with("test-app", None)
+        mock_get_alb_url.assert_called_once_with("test-app", "test-app-ecs")
+        mock_get_aws_client.assert_called_once_with("ecs")
+
+    @mock.patch("awslabs.ecs_mcp_server.api.status.get_aws_client")
+    async def test_get_cfn_stack_status_success(self, mock_get_aws_client):
+        """Test successful CloudFormation stack status retrieval."""
+        # Setup mock response
+        mock_cfn_client = mock.MagicMock()
+        mock_cfn_client.describe_stacks.return_value = {
+            "Stacks": [
+                {
+                    "StackName": "test-stack",
+                    "StackStatus": "CREATE_COMPLETE",
+                    "CreationTime": datetime.datetime.now(),
+                    "LastUpdatedTime": datetime.datetime.now(),
+                    "Outputs": [
+                        {"OutputKey": "OutputKey1", "OutputValue": "OutputValue1"},
+                        {"OutputKey": "OutputKey2", "OutputValue": "OutputValue2"},
+                    ],
+                }
+            ]
+        }
+        mock_cfn_client.describe_stack_events.return_value = {
+            "StackEvents": [
+                {
+                    "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/test-stack/abcdef",
+                    "EventId": "event1",
+                    "StackName": "test-stack",
+                    "LogicalResourceId": "resource1",
+                    "ResourceType": "AWS::ECS::Service",
+                    "Timestamp": datetime.datetime.now(),
+                    "ResourceStatus": "CREATE_COMPLETE",
+                    "ResourceStatusReason": "Resource creation complete",
+                },
+                {
+                    "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/test-stack/abcdef",
+                    "EventId": "event2",
+                    "StackName": "test-stack",
+                    "LogicalResourceId": "resource2",
+                    "ResourceType": "AWS::EC2::SecurityGroup",
+                    "Timestamp": datetime.datetime.now() - datetime.timedelta(minutes=1),
+                    "ResourceStatus": "CREATE_COMPLETE",
+                },
+            ]
+        }
+        
+        mock_get_aws_client.return_value = mock_cfn_client
+        
+        # Call the function
+        result = await status._get_cfn_stack_status("test-stack")
+        
+        # Verify the result
+        assert result["status"] == "CREATE_COMPLETE"
+        assert "creation_time" in result
+        assert "last_updated_time" in result
+        assert len(result["outputs"]) == 2
+        assert result["outputs"]["OutputKey1"] == "OutputValue1"
+        assert len(result["recent_events"]) == 2
+        assert result["recent_events"][0]["resource_type"] == "AWS::ECS::Service"
+        assert result["recent_events"][0]["status"] == "CREATE_COMPLETE"
+        assert result["recent_events"][0]["reason"] == "Resource creation complete"
+        
+        # Verify the function calls
+        mock_get_aws_client.assert_called_once_with("cloudformation")
+        mock_cfn_client.describe_stacks.assert_called_once_with(StackName="test-stack")
+        mock_cfn_client.describe_stack_events.assert_called_once_with(StackName="test-stack")
+
+    @mock.patch("awslabs.ecs_mcp_server.api.status.get_aws_client")
+    async def test_get_cfn_stack_status_not_found(self, mock_get_aws_client):
+        """Test CloudFormation stack status retrieval when stack is not found."""
+        # Setup mock response
+        mock_cfn_client = mock.MagicMock()
+        mock_cfn_client.describe_stacks.side_effect = ClientError(
+            {"Error": {"Code": "ValidationError", "Message": "Stack with id test-stack does not exist"}},
+            "DescribeStacks"
+        )
+        
+        mock_get_aws_client.return_value = mock_cfn_client
+        
+        # Call the function
+        result = await status._get_cfn_stack_status("test-stack")
+        
+        # Verify the result
+        assert result["status"] == "NOT_FOUND"
+        assert "details" in result
+        assert "test-stack not found" in result["details"]
+        
+        # Verify the function calls
+        mock_get_aws_client.assert_called_once_with("cloudformation")
+        mock_cfn_client.describe_stacks.assert_called_once_with(StackName="test-stack")
+
+    @mock.patch("awslabs.ecs_mcp_server.api.status._get_cfn_stack_status")
+    async def test_find_cloudformation_stack_with_explicit_stack_name(self, mock_get_cfn_stack_status):
+        """Test finding a CloudFormation stack with an explicitly provided name."""
+        # Setup mock response
+        mock_get_cfn_stack_status.return_value = {
+            "status": "CREATE_COMPLETE",
+            "outputs": {},
+            "recent_events": []
+        }
+        
+        # Call the function with explicit stack name
+        stack_name, stack_status = await status._find_cloudformation_stack("test-app", "explicit-stack")
+        
+        # Verify the result
+        assert stack_name == "explicit-stack"
+        assert stack_status["status"] == "CREATE_COMPLETE"
+        
+        # Verify the function calls
+        mock_get_cfn_stack_status.assert_called_once_with("explicit-stack")
+
+    @mock.patch("awslabs.ecs_mcp_server.api.status._get_cfn_stack_status")
+    async def test_find_cloudformation_stack_with_patterns(self, mock_get_cfn_stack_status):
+        """Test finding a CloudFormation stack using patterns."""
+        # Setup mock responses for different stack name patterns
+        mock_get_cfn_stack_status.side_effect = [
+            {"status": "NOT_FOUND", "details": "Stack test-app-ecs-infrastructure not found"},  # First pattern fails
+            {"status": "CREATE_COMPLETE", "outputs": {}, "recent_events": []}  # Second pattern succeeds
+        ]
+        
+        # Call the function without explicit stack name
+        stack_name, stack_status = await status._find_cloudformation_stack("test-app")
+        
+        # Verify the result
+        assert stack_name == "test-app-ecs"  # Should find the second pattern
+        assert stack_status["status"] == "CREATE_COMPLETE"
+        
+        # Verify the function calls
+        assert mock_get_cfn_stack_status.call_count == 2
+        mock_get_cfn_stack_status.assert_has_calls([
+            mock.call("test-app-ecs-infrastructure"),
+            mock.call("test-app-ecs")
+        ])
+
+    @mock.patch("awslabs.ecs_mcp_server.api.status._get_cfn_stack_status")
+    async def test_find_cloudformation_stack_not_found(self, mock_get_cfn_stack_status):
+        """Test when no CloudFormation stack is found."""
+        # Setup mock responses for all patterns to fail
+        mock_get_cfn_stack_status.side_effect = [
+            {"status": "NOT_FOUND", "details": "Stack test-app-ecs-infrastructure not found"},
+            {"status": "NOT_FOUND", "details": "Stack test-app-ecs not found"}
+        ]
+        
+        # Call the function
+        stack_name, stack_status = await status._find_cloudformation_stack("test-app")
+        
+        # Verify the result
+        assert stack_name is None
+        assert stack_status["status"] == "NOT_FOUND"
+        assert "No stack found with any naming pattern" in stack_status["details"]
+        
+        # Verify the function calls
+        assert mock_get_cfn_stack_status.call_count == 2
+        mock_get_cfn_stack_status.assert_has_calls([
+            mock.call("test-app-ecs-infrastructure"),
+            mock.call("test-app-ecs")
+        ])
+
+    @mock.patch("awslabs.ecs_mcp_server.api.status.get_aws_client")
+    async def test_get_alb_url_with_known_stack(self, mock_get_aws_client):
+        """Test ALB URL retrieval with a known stack name."""
+        # Setup mock response
+        mock_cfn_client = mock.MagicMock()
+        mock_cfn_client.describe_stacks.return_value = {
+            "Stacks": [
+                {
+                    "Outputs": [
+                        {"OutputKey": "LoadBalancerDNS", "OutputValue": "test-alb-123.us-west-2.elb.amazonaws.com"}
+                    ]
+                }
+            ]
+        }
+        mock_get_aws_client.return_value = mock_cfn_client
+        
+        # Call the function with known stack name
+        result = await status._get_alb_url("test-app", "known-stack")
+        
+        # Verify the result
+        assert result == "http://test-alb-123.us-west-2.elb.amazonaws.com"
+        
+        # Verify the function calls
+        mock_get_aws_client.assert_called_once_with("cloudformation")
+        mock_cfn_client.describe_stacks.assert_called_once_with(StackName="known-stack")
+
+    @mock.patch("awslabs.ecs_mcp_server.api.status.get_aws_client")
+    async def test_get_alb_url_with_http_prefix(self, mock_get_aws_client):
+        """Test ALB URL retrieval when URL already has http:// prefix."""
+        # Setup mock response
+        mock_cfn_client = mock.MagicMock()
+        mock_cfn_client.describe_stacks.return_value = {
+            "Stacks": [
+                {
+                    "Outputs": [
+                        {"OutputKey": "LoadBalancerUrl", "OutputValue": "http://test-alb-123.us-west-2.elb.amazonaws.com"}
+                    ]
+                }
+            ]
+        }
+        mock_get_aws_client.return_value = mock_cfn_client
+        
+        # Call the function
+        result = await status._get_alb_url("test-app", "test-stack")
+        
+        # Verify the result - should not add another http:// prefix
+        assert result == "http://test-alb-123.us-west-2.elb.amazonaws.com"
+        
+        # Verify the function calls
+        mock_get_aws_client.assert_called_once_with("cloudformation")
+        mock_cfn_client.describe_stacks.assert_called_once_with(StackName="test-stack")
+
+    @mock.patch("awslabs.ecs_mcp_server.api.status.get_aws_client")
+    async def test_get_alb_url_not_found(self, mock_get_aws_client):
+        """Test ALB URL retrieval when no ALB URL is found in any stack."""
+        # Setup mock responses for different stack name patterns
+        mock_cfn_client = mock.MagicMock()
+        mock_cfn_client.describe_stacks.side_effect = [
+            # First stack doesn't have LoadBalancer outputs
+            {"Stacks": [{"Outputs": [{"OutputKey": "OtherOutput", "OutputValue": "value"}]}]},
+            # Second stack call raises an exception
+            ClientError(
+                {"Error": {"Code": "ValidationError", "Message": "Stack with id test-app-ecs does not exist"}},
+                "DescribeStacks"
+            )
+        ]
+        mock_get_aws_client.return_value = mock_cfn_client
+        
+        # Call the function without known stack name
+        result = await status._get_alb_url("test-app")
+        
+        # Verify the result
+        assert result is None
+        
+        # Verify the function calls
+        mock_get_aws_client.assert_called_once_with("cloudformation")
+        assert mock_cfn_client.describe_stacks.call_count == 2
+        mock_cfn_client.describe_stacks.assert_has_calls([
+            mock.call(StackName="test-app-ecs-infrastructure"),
+            mock.call(StackName="test-app-ecs")
+        ])
+
+    def test_get_stack_names_to_try(self):
+        """Test stack name generation function."""
+        # Test with no provided stack name
+        stack_names = status._get_stack_names_to_try("test-app")
+        assert len(stack_names) == 2
+        assert "test-app-ecs-infrastructure" == stack_names[0]
+        assert "test-app-ecs" == stack_names[1]
+        
+        # Test with provided stack name
+        stack_names = status._get_stack_names_to_try("test-app", "custom-stack")
+        assert len(stack_names) == 3
+        assert "custom-stack" == stack_names[0]
+        assert "test-app-ecs-infrastructure" == stack_names[1]
+        assert "test-app-ecs" == stack_names[2]
+        
+        # Test duplicate avoidance (if provided stack name matches a pattern)
+        stack_names = status._get_stack_names_to_try("test-app", "test-app-ecs")
+        assert len(stack_names) == 2
+        assert "test-app-ecs" == stack_names[0]
+        assert "test-app-ecs-infrastructure" == stack_names[1]
+    
+    def test_generate_custom_domain_guidance(self):
+        """Test custom domain guidance generation."""
+        # Call the function
+        result = status._generate_custom_domain_guidance("test-app", "http://test-alb-123.us-west-2.elb.amazonaws.com")
+        
+        # Verify the result contains all required sections
+        assert "custom_domain" in result
+        assert "https_setup" in result
+        assert "cloudformation_update" in result
+        assert "next_steps" in result
+        
+        # Verify the custom domain section
+        custom_domain = result["custom_domain"]
+        assert "title" in custom_domain
+        assert "description" in custom_domain
+        assert "steps" in custom_domain
+        assert "route53_commands" in custom_domain
+        assert len(custom_domain["steps"]) >= 3
+        
+        # Verify the HTTPS setup section
+        https_setup = result["https_setup"]
+        assert "title" in https_setup
+        assert "description" in https_setup
+        assert "steps" in https_setup
+        assert "acm_commands" in https_setup
+        assert len(https_setup["steps"]) >= 3
+        
+        # Verify the CloudFormation update section
+        cf_update = result["cloudformation_update"]
+        assert "title" in cf_update
+        assert "description" in cf_update
+        assert "steps" in cf_update
+        assert "commands" in cf_update
+        
+        # Verify the ALB hostname is correctly extracted
+        alb_hostname = "test-alb-123.us-west-2.elb.amazonaws.com"
+        route53_commands = "\n".join(custom_domain["route53_commands"])
+        assert alb_hostname in route53_commands
+        assert "test-app" in route53_commands
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/ecs-mcp-server/tests/unit/utils/test_time_utils.py
+++ b/src/ecs-mcp-server/tests/unit/utils/test_time_utils.py
@@ -1,0 +1,60 @@
+"""
+Unit tests for the time_utils module.
+"""
+
+import datetime
+import unittest
+
+from awslabs.ecs_mcp_server.utils.time_utils import calculate_time_window
+
+
+class TestTimeUtils(unittest.TestCase):
+    """Unit tests for the time_utils module."""
+    
+    def test_default_time_window(self):
+        """Test with default parameters."""
+        start_time, end_time = calculate_time_window()
+        self.assertIsNotNone(start_time)
+        self.assertIsNotNone(end_time)
+        self.assertEqual((end_time - start_time).total_seconds(), 3600)
+        
+    def test_explicit_start_time(self):
+        """Test with explicit start_time parameter."""
+        now = datetime.datetime.now(datetime.timezone.utc)
+        start = now - datetime.timedelta(hours=2)
+        start_time, end_time = calculate_time_window(start_time=start)
+        self.assertEqual(start_time, start)
+        self.assertTrue((end_time - now).total_seconds() < 5)  # Within 5 seconds of now
+        
+    def test_explicit_end_time(self):
+        """Test with explicit end_time parameter."""
+        end = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)
+        start_time, end_time = calculate_time_window(end_time=end)
+        self.assertEqual(end_time, end)
+        self.assertEqual((end_time - start_time).total_seconds(), 3600)
+        
+    def test_both_times_specified(self):
+        """Test with both start_time and end_time specified."""
+        start = datetime.datetime(2025, 5, 1, tzinfo=datetime.timezone.utc)
+        end = datetime.datetime(2025, 5, 2, tzinfo=datetime.timezone.utc)
+        start_time, end_time = calculate_time_window(start_time=start, end_time=end)
+        self.assertEqual(start_time, start)
+        self.assertEqual(end_time, end)
+        
+    def test_timezone_handling(self):
+        """Test handling of timezone-naive datetime objects."""
+        naive_start = datetime.datetime(2025, 5, 1)
+        naive_end = datetime.datetime(2025, 5, 2)
+        start_time, end_time = calculate_time_window(start_time=naive_start, end_time=naive_end)
+        self.assertIsNotNone(start_time.tzinfo)
+        self.assertIsNotNone(end_time.tzinfo)
+        self.assertEqual(start_time.day, naive_start.day)
+        self.assertEqual(end_time.day, naive_end.day)
+
+    def test_custom_time_window(self):
+        """Test with custom time window."""
+        # Using a 2-hour window (7200 seconds)
+        start_time, end_time = calculate_time_window(time_window=7200)
+        self.assertIsNotNone(start_time)
+        self.assertIsNotNone(end_time)
+        self.assertEqual((end_time - start_time).total_seconds(), 7200)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

### Changes

- Consolidation of the troubleshooting tools into one
- Some bug fixes from prev. PR

### User experience
- User experience stays the same, except they will notice that instead of multiple troubleshooting tools, there is one consolidated one


### Next steps
- PR with the analyze network troubleshooting tool
- PR with the readme updates

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [Y] I have reviewed the [contributing guidelines](https://github.com/awslabs/mcp/blob/main/CONTRIBUTING.md)
* [Y] I have performed a self-review of this change
* [Y] Changes have been tested
* [Y] Changes are documented

Is this a breaking change? (Y/N)

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/awslabs/mcp/blob/main/LICENSE).
